### PR TITLE
Fix fulscrn

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -496,9 +496,12 @@ void MainWindow::slotFullscreen()
           emit signalFullscreenEnabled ( true );
      } else {
           showMenuBar();
-          restoreWindowGeometry();
           this->setWindowFlags ( windowFlags() & ~Qt::FramelessWindowHint );
-          this->windowState() & Qt::WindowMaximized ? this->showMaximized() : this->show();
+          this->show();
+          restoreWindowGeometry();
+          if (this->windowState() & Qt::WindowMaximized) {
+               this->showMaximized();
+          }
           this->activateWindow();
           this->raise();
           emit signalFullscreenEnabled ( false );

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -496,9 +496,9 @@ void MainWindow::slotFullscreen()
           emit signalFullscreenEnabled ( true );
      } else {
           showMenuBar();
-          this->setWindowFlags ( windowFlags() & ~Qt::FramelessWindowHint );
-          this->show();
           restoreWindowGeometry();
+          this->setWindowFlags ( windowFlags() & ~Qt::FramelessWindowHint );
+          this->windowState() & Qt::WindowMaximized ? this->showMaximized() : this->show();
           this->activateWindow();
           this->raise();
           emit signalFullscreenEnabled ( false );


### PR DESCRIPTION
When going from maximized screen -> fullscreen in non-borderless mode, you will become trapped in fullscreen mode. 
You can escape by switching to borderless mode but qimgv misbehaves badly after that. To prevent this you need this ordering:

[restoreWindowGeometry()] -> [showMaximized()] OR [showNormal()]


showMaximized behaves better. When coming out of borderless fullscreen, the menu bar will get messed up unless you have exactly this ordering:

SetWindowFlags to NOT frameless -> [show()] -> [restoreWindowGeometry()]


So you can see that the order you can call the functions in is pretty rigid. These are the minimum changes for correct behavior on my PC/Windows.
A more elegant solution could probably be made by splitting fullscreen handling of borderless and nonborderless mode completely, or by digging into Qt's source to figure out how the hell this garbage works.