### PR TITLE
Fix webm

### DIFF
--- a/core.cpp
+++ b/core.cpp
@@ -164,7 +164,7 @@ void Core::stopAnimation() {
                        this, SIGNAL(frameChanged(QPixmap *)));
         }
         if((currentVideo = dynamic_cast<Video *>(currentImage())) != NULL) {
-            emit videoChanged(currentVideo->filePath());
+            emit stopVideo();
         }
     }
 }

--- a/core.cpp
+++ b/core.cpp
@@ -105,7 +105,9 @@ void Core::rotateImage(int degrees) {
     if(currentImage() != NULL) {
         currentImage()->rotate(degrees);
         updateInfoString();
+        if (currentImage()->getPixmap() != NULL){
         emit imageAltered(currentImage()->getPixmap());
+        }
     }
 }
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -103,6 +103,9 @@ void MainWindow::init() {
     connect(core, SIGNAL(videoChanged(QString)),
             this, SLOT(openVideo(QString)), Qt::UniqueConnection);
 
+    connect(core, SIGNAL(stopVideo()),
+            this, SLOT(disableVideoPlayer()));
+
     core->init();
 
     //##############################################################

--- a/newloader.cpp
+++ b/newloader.cpp
@@ -103,10 +103,10 @@ void NewLoader::onLoadFinished(int loaded) {
         emit loadFinished(cache->imageAt(loaded), loaded);
         current = cache->imageAt(loaded);
     } else if(isRelevant(loaded)) {
-        //qDebug() << "loadfinished image is revelant, keeping.." << loaded;
+        //qDebug() << "loadfinished image is relevant, keeping.." << loaded;
     } else {
         cache->unloadAt(loaded);
-        //qDebug() << "load finished but not revelant ("<< loaded <<"). deleting..";
+        //qDebug() << "load finished but not relevant ("<< loaded <<"). deleting..";
     }
 }
 

--- a/newloader.cpp
+++ b/newloader.cpp
@@ -102,7 +102,7 @@ void NewLoader::onLoadFinished(int loaded) {
     if(loaded == loadTarget && current != cache->imageAt(loaded)) {
         emit loadFinished(cache->imageAt(loaded), loaded);
         current = cache->imageAt(loaded);
-    } else if(isRevelant(loaded)) {
+    } else if(isRelevant(loaded)) {
         //qDebug() << "loadfinished image is revelant, keeping.." << loaded;
     } else {
         cache->unloadAt(loaded);
@@ -110,7 +110,7 @@ void NewLoader::onLoadFinished(int loaded) {
     }
 }
 
-bool NewLoader::isRevelant(int pos) {
+bool NewLoader::isRelevant(int pos) {
     return !(pos < loadTarget - 1 || pos > loadTarget + 1);
 }
 
@@ -125,7 +125,7 @@ void NewLoader::onLoadTimeout() {
 
 void NewLoader::onPreloadTimeout() {
     mutex.lock();
-    if(isRevelant(preloadTarget)) {
+    if(isRelevant(preloadTarget)) {
         worker->setTarget(preloadTarget, dm->filePathAt(preloadTarget));
         //qDebug()<< "PRELOAD " << worker->target();
         emit startLoad();
@@ -135,7 +135,7 @@ void NewLoader::onPreloadTimeout() {
 
 void NewLoader::freeAuto() {
     for(int i = 0; i < cache->length(); i++) {
-        if(!isRevelant(i) && cache->isLoaded(i)) {
+        if(!isRelevant(i) && cache->isLoaded(i)) {
             bool flag = false;
             if(cache->imageAt(i) == current) {
                 flag = true;
@@ -154,7 +154,7 @@ void NewLoader::freeAll() {
 }
 
 void NewLoader::freeAt(int toUnload) {
-    if(!isRevelant(toUnload)) {
+    if(!isRelevant(toUnload)) {
         //qDebug() << "!!!deleting" << toUnload << "  "<< cache->imageAt(toUnload);
         if(current == cache->imageAt(toUnload)) {
             current = NULL;

--- a/newloader.h
+++ b/newloader.h
@@ -44,7 +44,7 @@ private:
     QTimer *loadTimer, *preloadTimer;
 
     void freeAll();
-    bool isRevelant(int pos);
+    bool isRelevant(int pos);
 signals:
     void loadStarted();
     void loadFinished(Image*, int pos);

--- a/viewers/videoplayer.cpp
+++ b/viewers/videoplayer.cpp
@@ -7,6 +7,7 @@ VideoPlayer::VideoPlayer(QWidget *parent) :
     scene = new QGraphicsScene;
     videoItem = new QGraphicsVideoItem();
     mediaPlayer.setVideoOutput(videoItem);
+    retries = 1;
 
     scene->addItem(videoItem);
     this->setRenderHint(QPainter::SmoothPixmapTransform);
@@ -92,8 +93,13 @@ void VideoPlayer::handlePlayerStateChange(QMediaPlayer::State state) {
     Q_UNUSED(state)
 }
 
+// Try reloading video if it fails
 void VideoPlayer::handleError() {
     qDebug() << "VideoPlayer: Error - " + mediaPlayer.errorString();
+    while (retries>0){
+    play(path);
+    retries--;
+    }
 }
 
 void VideoPlayer::mouseMoveEvent(QMouseEvent *event) {

--- a/viewers/videoplayer.h
+++ b/viewers/videoplayer.h
@@ -40,6 +40,7 @@ private:
     QString path;
     QGraphicsScene *scene;
     QGraphicsVideoItem *videoItem;
+    int retries;
 
 protected:
     virtual void mouseMoveEvent(QMouseEvent *event);


### PR DESCRIPTION
This is intended to fix problems with loading certain webms. Specifically, the webms Qt has occasional troubles with are webms which have had their sound stripped (commonly found on image boards.) webms with sound seem to usually work fine.