### PR TITLE
core.cpp: check against __GLIBC__ no __linux__

### DIFF
--- a/core.cpp
+++ b/core.cpp
@@ -16,7 +16,7 @@ Core::Core()
       scaler(nullptr),
       thumbnailer(nullptr)
 {
-#ifdef __linux__
+#ifdef __GLIBC__
     // default value of 128k causes memory fragmentation issues
     // finding this took 3 days of my life
     mallopt(M_MMAP_THRESHOLD, 64000);


### PR DESCRIPTION
musl is a linux libc but it doesn't implement mallopt neither provides
M_MMAP_THRESHOLD

resolves easymodo/qimgv#57

error:

```
[  8%] Building CXX object CMakeFiles/qimgv.dir/shortcutbuilder.cpp.o
/builddir/qimgv-0.7/core.cpp: In constructor 'Core::Core()':
/builddir/qimgv-0.7/core.cpp:22:13: error: 'M_MMAP_THRESHOLD' was not declared in this scope
     mallopt(M_MMAP_THRESHOLD, 64000);
             ^~~~~~~~~~~~~~~~
/builddir/qimgv-0.7/core.cpp:22:5: error: 'mallopt' was not declared in this scope
     mallopt(M_MMAP_THRESHOLD, 64000);
     ^~~~~~~
/builddir/qimgv-0.7/core.cpp:22:5: note: suggested alternative: 'malloc'
     mallopt(M_MMAP_THRESHOLD, 64000);
     ^~~~~~~
     malloc
[  9%] Building CXX object CMakeFiles/qimgv.dir/components/actionmanager/actionmanager.cpp.o
make[2]: *** [CMakeFiles/qimgv.dir/build.make:155: CMakeFiles/qimgv.dir/core.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:73: CMakeFiles/qimgv.dir/all] Error 2
make: *** [Makefile:130: all] Error 2
```