### PR TITLE
Allow HiDPI pixmaps

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -35,6 +35,7 @@ int main(int argc, char *argv[]) {
     //qputenv("QT_SCREEN_SCALE_FACTORS", "1;1.7");
 
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
     QApplication a(argc, argv);
     QCoreApplication::setOrganizationName("greenpepper software");
     QCoreApplication::setOrganizationDomain("github.com/easymodo/qimgv");


### PR DESCRIPTION
This commit gives Qt permission to use HiDPI pixmaps in order to make
icons look much nicer on high-resolution displays. Sadly, this won't
work for icons shipped with qimgv since there is only one set of
prerendered PNG icons.