### PR TITLE
Support libc++ 9.0.0 and above

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,14 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 message(STATUS "Build configuration: " ${CMAKE_BUILD_TYPE})
 
-# COMPILE FLAGS
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -lstdc++fs -O3")
+# detect if libstdc++ is in use to know if libstdc++fs should be linked
+include(CheckCXXSourceCompiles)
+check_cxx_source_compiles("#include <iostream>
+    #ifndef __GLIBCXX__
+    #error not using libstdc+++
+    #endif
+    int main() { return 0; }"
+    USING_LIBSTDCXX)
 
 # check requirements for std::filesystem
 if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0)

--- a/qimgv/CMakeLists.txt
+++ b/qimgv/CMakeLists.txt
@@ -15,7 +15,10 @@ QT5_ADD_RESOURCES(RES resources.qrc)
 add_executable(qimgv ${SRC} ${SRC_Components} ${SRC_SourceContainers} ${SRC_Utils} ${SRC_Gui} ${RES} ${SRC_UI_Files} qimgv.rc)
 
 # LINK STUFF
-target_link_libraries(qimgv Qt5::Core Qt5::Widgets Qt5::Concurrent stdc++fs)
+target_link_libraries(qimgv Qt5::Core Qt5::Widgets Qt5::Concurrent)
+if(USING_LIBSTDCXX)
+    target_link_libraries(qimgv stdc++fs)
+endif()
 #target_link_libraries(qimgv Qt5::Core Qt5::Widgets Qt5::Concurrent Qt5::QWindowsIntegrationPlugin stdc++fs)
 
 # OPTION DEFINITIONS, LINKING

--- a/qimgv/components/directorymanager/directorymanager.cpp
+++ b/qimgv/components/directorymanager/directorymanager.cpp
@@ -360,7 +360,7 @@ void DirectoryManager::generateFileList() {
                 newEntry.size = entry.file_size();
                 newEntry.modifyTime = entry.last_write_time();
                 newEntry.isDirectory = entry.is_directory();
-            } catch (const std::filesystem::__cxx11::filesystem_error &err) {
+            } catch (const std::filesystem::filesystem_error &err) {
                 qDebug() << "[DirectoryManager]" << err.what();
                 continue;
             }

--- a/qimgv/main.cpp
+++ b/qimgv/main.cpp
@@ -67,7 +67,7 @@ int main(int argc, char *argv[]) {
     // init
     // needed for mpv
 #ifndef _MSC_VER
-    std::setlocale(LC_NUMERIC, "C");
+    setlocale(LC_NUMERIC, "C");
 #endif
     qRegisterMetaTypeStreamOperators<Script>("Script");
 


### PR DESCRIPTION
detect if C++ library is in use, and only link libstdc++fs if so.
only support libc++ 9 and above because in earlier versions libc++ also
had a separate filesystem library.

remove line modifying CMAKE_CXX_FLAGS, as it adds C++ standard
specification already dealt with through CMAKE_CXX_STANDARD,
unconditionally links libstdc++fs, and unconditionally adds -O3, which
would be done automatically by cmake for the project's default build
type of "Release", and shouldn't be for users of other build types.