### PR TITLE
include GNUInstallDirs

### DIFF
--- a/qimgv/CMakeLists.txt
+++ b/qimgv/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(GNUInstallDirs)
+
 # ADD EXECUTABLE
 add_executable(qimgv
     appversion.cpp


### PR DESCRIPTION
make sure CMAKE_INSTALL_FULL_DATAROOTDIR is correctly populated.
Forgot to include this in my original cmake refactoring PR leading to the file installation being in the wrong directories, due to CMAKE_INSTALL_FULL_DATAROOTDIR being empty.