### PR TITLE
Resize Image by Percent

### DIFF
--- a/qimgv/gui/dialogs/resizedialog.h
+++ b/qimgv/gui/dialogs/resizedialog.h
@@ -1,14 +1,17 @@
 #pragma once
 
-#include <QDialog>
-#include <QVBoxLayout>
-#include <QHBoxLayout>
-#include <QPushButton>
-#include <QSpinBox>
 #include <QCheckBox>
-#include <QLabel>
-#include <QDesktopWidget>
 #include <QDebug>
+#include <QDesktopWidget>
+#include <QDialog>
+#include <QDoubleSpinBox>
+#include <QHBoxLayout>
+#include <QKeyEvent>
+#include <QLabel>
+#include <QPushButton>
+#include <QRadioButton>
+#include <QSpinBox>
+#include <QVBoxLayout>
 
 namespace Ui {
     class ResizeDialog;
@@ -24,6 +27,10 @@ public:
 
 public slots:
     int exec();
+
+protected:
+    void keyPressEvent(QKeyEvent *event);
+
 private:
     Ui::ResizeDialog *ui;
     QSize originalSize, targetSize, desktopSize;
@@ -34,6 +41,7 @@ private:
 private slots:
     void widthChanged(int);
     void heightChanged(int);
+    void percentChanged(double);
     void sizeSelect();
 
     void setCommonResolution(int);
@@ -41,6 +49,8 @@ private slots:
     void fitDesktop();
     void fillDesktop();
     void onAspectRatioCheckbox();
+    void onPercentageRadioButton();
+    void onAbsoluteSizeRadioButton();
 signals:
     void sizeSelected(QSize);
 };

--- a/qimgv/gui/dialogs/resizedialog.ui
+++ b/qimgv/gui/dialogs/resizedialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>489</width>
-    <height>270</height>
+    <height>340</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -44,40 +44,90 @@
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_3">
         <item>
-         <layout class="QGridLayout" name="resGridLayout">
-          <item row="0" column="1">
-           <widget class="QSpinBox" name="width">
+         <layout class="QVBoxLayout" name="verticalLayout_6">
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QRadioButton" name="byPercentage">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>30</height>
-             </size>
+            <property name="text">
+             <string>By Percent:</string>
             </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-            <property name="buttonSymbols">
-             <enum>QAbstractSpinBox::NoButtons</enum>
-            </property>
-            <property name="keyboardTracking">
-             <bool>false</bool>
-            </property>
-            <property name="minimum">
-             <number>1</number>
-            </property>
-            <property name="maximum">
-             <number>65535</number>
+            <property name="checked">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
+          <item>
+           <widget class="QRadioButton" name="byAbsoluteSize">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>By Absolute Size:</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QGridLayout" name="resGridLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_3">
+            <property name="font">
+             <font>
+              <italic>true</italic>
+             </font>
+            </property>
+            <property name="text">
+             <string>Percent:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="font">
+             <font>
+              <italic>true</italic>
+             </font>
+            </property>
+            <property name="text">
+             <string>Width:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
            <widget class="QSpinBox" name="height">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
               <horstretch>0</horstretch>
@@ -100,7 +150,7 @@
              <enum>QAbstractSpinBox::NoButtons</enum>
             </property>
             <property name="keyboardTracking">
-             <bool>false</bool>
+             <bool>true</bool>
             </property>
             <property name="minimum">
              <number>1</number>
@@ -110,28 +160,41 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label">
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="width">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
-            <property name="font">
-             <font>
-              <italic>true</italic>
-             </font>
-            </property>
-            <property name="text">
-             <string>Width:</string>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>30</height>
+             </size>
             </property>
             <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             <set>Qt::AlignCenter</set>
+            </property>
+            <property name="buttonSymbols">
+             <enum>QAbstractSpinBox::NoButtons</enum>
+            </property>
+            <property name="keyboardTracking">
+             <bool>true</bool>
+            </property>
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>65535</number>
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
+          <item row="2" column="0">
            <widget class="QLabel" name="label_2">
             <property name="font">
              <font>
@@ -143,6 +206,52 @@
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QDoubleSpinBox" name="percent">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>30</height>
+             </size>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+            <property name="readOnly">
+             <bool>false</bool>
+            </property>
+            <property name="buttonSymbols">
+             <enum>QAbstractSpinBox::NoButtons</enum>
+            </property>
+            <property name="decimals">
+             <number>1</number>
+            </property>
+            <property name="minimum">
+             <double>1.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>1600.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>1.000000000000000</double>
+            </property>
+            <property name="stepType">
+             <enum>QAbstractSpinBox::AdaptiveDecimalStepType</enum>
+            </property>
+            <property name="value">
+             <double>100.000000000000000</double>
             </property>
            </widget>
           </item>
@@ -491,6 +600,21 @@
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <tabstops>
+  <tabstop>byPercentage</tabstop>
+  <tabstop>byAbsoluteSize</tabstop>
+  <tabstop>percent</tabstop>
+  <tabstop>width</tabstop>
+  <tabstop>height</tabstop>
+  <tabstop>keepAspectRatio</tabstop>
+  <tabstop>comboBox</tabstop>
+  <tabstop>resComboBox</tabstop>
+  <tabstop>fitDesktopButton</tabstop>
+  <tabstop>fillDesktopButton</tabstop>
+  <tabstop>resetButton</tabstop>
+  <tabstop>okButton</tabstop>
+  <tabstop>cancelButton</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/qimgv/res/styles/style-template.qss
+++ b/qimgv/res/styles/style-template.qss
@@ -257,13 +257,17 @@ SidePanel QDoubleSpinBox:focus
     border-color: %button%;
 }
 
-SidePanel QSpinBox::up-button, QDoubleSpinBox::up-button  {
+SidePanel QSpinBox::up-button,
+SidePanel QDoubleSpinBox::up-button
+{
     max-width: 0px;
     max-height: 0px;
     width:0px;
 }
 
-SidePanel QSpinBox::down-button, QDoubleSpinBox::down-button {
+SidePanel QSpinBox::down-button,
+SidePanel QDoubleSpinBox::down-button
+{
     max-width: 0px;
     max-height: 0px;
     width:0px;


### PR DESCRIPTION
A new resize dialog box implementation to adjust the image by
percentage, scaling width and height identically i.e. keep aspect ratio.
Makes it easier to scale by exact multiples like x2 or x4.

I'm not very familiar with Github pull requests so hopefully I did it all right.