### PR TITLE
Add JXL animation support

### DIFF
--- a/qimgv/sourcecontainers/documentinfo.cpp
+++ b/qimgv/sourcecontainers/documentinfo.cpp
@@ -95,6 +95,9 @@ void DocumentInfo::detectFormat() {
     } else if(mimeName == "image/webp" || (mimeName == "audio/x-riff" && suffix == "webp")) {
         mFormat = "webp";
         mDocumentType = detectAnimatedWebP() ? DocumentType::ANIMATED : DocumentType::STATIC;
+    } else if(mimeName == "image/jxl") {
+        mFormat = "jxl";
+        mDocumentType = detectAnimatedJxl() ? DocumentType::ANIMATED : DocumentType::STATIC;
     } else if(mimeName == "image/bmp") {
         mFormat = "bmp";
         mDocumentType = DocumentType::STATIC;
@@ -146,6 +149,11 @@ bool DocumentInfo::detectAnimatedWebP() {
         free(buf);
     }
     return result;
+}
+
+bool DocumentInfo::detectAnimatedJxl() {
+    QImageReader r(fileInfo.filePath(), "jxl");
+    return r.imageCount() > 1;
 }
 
 void DocumentInfo::loadExifTags() {

--- a/qimgv/sourcecontainers/documentinfo.h
+++ b/qimgv/sourcecontainers/documentinfo.h
@@ -60,6 +60,7 @@ private:
     void loadExifOrientation();
     bool detectAPNG();
     bool detectAnimatedWebP();
+    bool detectAnimatedJxl();
     QMap<QString, QString> exifTags;
     QMimeType mMimeType;
 };


### PR DESCRIPTION
To support animated _Jpeg XL_ images when using the _qt-jpegxl-image-plugin_