### PR TITLE
Add animation detection for AVIF and correct JXL

### DIFF
--- a/qimgv/sourcecontainers/documentinfo.h
+++ b/qimgv/sourcecontainers/documentinfo.h
@@ -61,6 +61,7 @@ private:
     bool detectAPNG();
     bool detectAnimatedWebP();
     bool detectAnimatedJxl();
+    bool detectAnimatedAvif();
     QMap<QString, QString> exifTags;
     QMimeType mMimeType;
 };


### PR DESCRIPTION
To support animated _AVIF_ images.

`detectAnimatedJxl` tweaked for faster _JXL_ files opening. ( [Thanks novomesk](https://github.com/easymodo/qimgv/pull/327#issuecomment-912320747) )