### PR TITLE
Exiv2::AnyError was removed

### DIFF
--- a/qimgv/sourcecontainers/documentinfo.cpp
+++ b/qimgv/sourcecontainers/documentinfo.cpp
@@ -269,7 +269,7 @@ void DocumentInfo::loadExifTags() {
         }
     }
     // No exception was caught, which may cause QT crash
-    catch (Exiv2::AnyError& e) {
+    catch (Exiv2::Error& e) {
         qDebug() << "Caught Exiv2 exception:\n" << e.what() << "\n";
         return;
     }


### PR DESCRIPTION
Exiv2 has removed Exiv2::AnyError and replaced it with Exiv2::Error in their code. Therefore have done the same with the one line in qimgv.