### PR TITLE
BUGFIX: Image Resize Policy (#508)

### DIFF
--- a/qimgv/gui/mainwindow.cpp
+++ b/qimgv/gui/mainwindow.cpp
@@ -942,7 +942,7 @@ void MW::adaptToWindowState() {
         if(showInfoBarFullscreen)
             infoBarFullscreen->showWhenReady();
         else
-            infoBarFullscreen->hide();    
+            infoBarFullscreen->hide();
 
         auto pos = settings->panelPosition();
         if(!settings->panelEnabled() || pos == PANEL_BOTTOM || pos == PANEL_LEFT)

--- a/qimgv/gui/viewers/imageviewerv2.h
+++ b/qimgv/gui/viewers/imageviewerv2.h
@@ -147,6 +147,7 @@ private:
     int dragThreshold = 10;
     float zoomStep = 0.1, dpr;
     float minScale, maxScale, fitWindowScale, expandLimit, lockedScale;
+    bool fitModeChanged;
     QPointF savedViewportPos;
     ViewLockMode mViewLock;
 


### PR DESCRIPTION
Original resize policy depends on conf attribute `expandImage` and
`expandLimit` which restrict the behavs of fitWidth & fitWindow. In some
extreme cases they just do nothing or even act as if something went
wrong.
The fixture ignores the conf and make the two fit methods as they should be.
