### PR TITLE
Commented line that causes slow video playback

### DIFF
--- a/plugins/player_mpv/src/mpvwidget.cpp
+++ b/plugins/player_mpv/src/mpvwidget.cpp
@@ -29,7 +29,7 @@ MpvWidget::MpvWidget(QWidget *parent, Qt::WindowFlags f)
         throw std::runtime_error("could not initialize mpv context");
 
     // Request hw decoding, just for testing.
-    mpv::qt::set_property(mpv, "hwdec", "auto");
+    //mpv::qt::set_property(mpv, "hwdec", "auto");
 
     //mpv::qt::set_property(mpv, "video-unscaled", "downscale-big");
 

--- a/plugins/player_mpv/src/nogl/mpvwidget.cpp
+++ b/plugins/player_mpv/src/nogl/mpvwidget.cpp
@@ -22,7 +22,7 @@ MpvWidget::MpvWidget(QWidget *parent, Qt::WindowFlags f)
     //mpv_set_option_string(mpv, "msg-level", "all=v");
 
     // Request hw decoding, just for testing.
-    mpv::qt::set_property(mpv, "hwdec", "auto");
+    //mpv::qt::set_property(mpv, "hwdec", "auto");
 
     //mpv::qt::set_property(mpv, "video-unscaled", "downscale-big");
 

--- a/qimgv/gui/panels/mainpanel/mainpanel.cpp
+++ b/qimgv/gui/panels/mainpanel/mainpanel.cpp
@@ -109,6 +109,7 @@ QSize MainPanel::sizeHint() const {
         case PANEL_RIGHT:
             return QSize(thumbnailStrip->itemSize().width() + 16, height());
     }
+    return QSize(0, 0);
 }
 
 void MainPanel::readSettings() {

--- a/qimgv/gui/viewers/imageviewerv2.cpp
+++ b/qimgv/gui/viewers/imageviewerv2.cpp
@@ -612,7 +612,7 @@ void ImageViewerV2::wheelEvent(QWheelEvent *event) {
                 centerIfNecessary();
                 snapToEdges();
             }
-            qDebug() << "trackpad";
+            // qDebug() << "trackpad";
         } else if(isWheel && settings->imageScrolling() == SCROLL_BY_TRACKPAD_AND_WHEEL) {
             // scroll by interval
             bool scrollable = false;
@@ -625,17 +625,17 @@ void ImageViewerV2::wheelEvent(QWheelEvent *event) {
                 event->accept();
                 scroll(0, -angleDelta.y(), true);
             } else {
-                qDebug() << "pass1";
+                // qDebug() << "pass1";
                 event->ignore(); // not scrollable; passthrough event
             }
         } else {
-            qDebug() << "pass2";
+           // qDebug() << "pass2";
            event->ignore();
            QWidget::wheelEvent(event);
         }
         saveViewportPos();
     } else {
-        qDebug() << "pass3";
+        // qDebug() << "pass3";
         event->ignore();
         QWidget::wheelEvent(event);
     }

--- a/qimgv/settings.cpp
+++ b/qimgv/settings.cpp
@@ -140,7 +140,7 @@ void Settings::loadStylesheet() {
         int context_menu_button_height = 32 * pDpr;
         int rename_overlay_width = 380 * pDpr;
 
-        qDebug()<< "dpr=" << qApp->devicePixelRatio() << "pDpr=" << pDpr;
+        //qDebug()<< "dpr=" << qApp->devicePixelRatio() << "pDpr=" << pDpr;
 
         // --- write variables into stylesheet --------------------------
         styleSheet.replace("%font_small%", QString::number(font_small)+"pt");


### PR DESCRIPTION
Hello, I commented on the lines mpv::qt::set_property(mpv, "hwdec", "auto"); because they are causing the videos to play very slowly at least on my machine. (I don't know if a PR should be created for this, or if others have the same problem)
I also commented on other lines with debug messages and another that causes an empty return value warning in the compilation.