### PR TITLE
Add FreeBSD to installation list

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,14 @@ xbps-install -S qimgv
 apk add qimgv
 ```
 
+## BSD
+
+### FreeBSD
+
+```
+pkg install qimgv
+```
+
 This list may be incomplete. 
 
 ## Compiling from source

--- a/qimgv/components/CMakeLists.txt
+++ b/qimgv/components/CMakeLists.txt
@@ -34,7 +34,7 @@ if(APPLE)
     #    directorymanager/watchers/linux/linuxfsevent.cpp
     #    directorymanager/watchers/linux/linuxwatcher.cpp
     #    directorymanager/watchers/linux/linuxworker.cpp)
-elseif(UNIX AND NOT (CMAKE_SYSTEM_NAME MATCHES ^FreeBSD$))
+elseif(UNIX)
     target_sources(qimgv PRIVATE
         directorymanager/watchers/linux/linuxfsevent.cpp
         directorymanager/watchers/linux/linuxwatcher.cpp


### PR DESCRIPTION
The FreeBSD port for qimgv has been accepted upstream. It will be available in the `/latest` package repo for `pkg` installation in a few days. It will be in the quarterly repos eventually but that will take longer.

While I'm at it, I'm reverting the unlinking inotify for FreeBSD commit, since it is supported by the port/package. If one wants to build qimgv from source on FreeBSD, they should do it in `/usr/ports/graphics/qimgv` which is now available in the [main repo](https://www.freshports.org/graphics/qimgv/).