### PR TITLE
Update workflow

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -16,40 +16,46 @@ jobs:
           msystem: MINGW64
           update: true
           install: git p7zip
-      - uses: actions/checkout@v3
+
+      - uses: actions/checkout@v4
         with: 
-#          ref: dev
+          #ref: dev
           fetch-depth: 0
+
       - id: build
         name: CI-Build
         run: |
           export BUILD_NAME="qimgv-x64_$(git describe --tags)"
-          echo "::set-output name=build_name::${BUILD_NAME}"
-          echo "::set-output name=build_file_name::${BUILD_NAME}.7z"
+          echo "build_name=${BUILD_NAME}" >> $GITHUB_OUTPUT
+          echo "build_file_name=${BUILD_NAME}.7z" >> $GITHUB_OUTPUT
           ./scripts/build-qimgv.sh
           pwd
           ls -al
           echo "running: 7z a qimgv-x64.7z ./${BUILD_NAME}"
           7z a qimgv-x64.7z ./${BUILD_NAME}
-      - uses: actions/upload-artifact@v3
+
+      - uses: actions/upload-artifact@v4
         with:
           name: qimgv-build
           path: qimgv-x64.7z
+
     outputs:
        build_name: ${{ steps.build.outputs.build_name }}
        build_file_name: ${{ steps.build.outputs.build_file_name }}
-       
+
   upload-release:
     runs-on: ubuntu-latest
     needs: build
     steps:
        #- run: echo "${{ needs.build.outputs.build_name }}"
-       - uses: actions/download-artifact@v3
+       - uses: actions/download-artifact@v4
          with: 
            name: qimgv-build
+
        - name: Rename archive
          run: mv qimgv-x64.7z "${{ needs.build.outputs.build_file_name }}"
-       - uses: softprops/action-gh-release@v1
+
+       - uses: softprops/action-gh-release@v2
          #if: startsWith(github.ref, 'refs/tags/')
          with:
            files: ${{ needs.build.outputs.build_file_name }}
@@ -57,7 +63,3 @@ jobs:
            tag_name: latest-dev
            name: ${{ needs.build.outputs.build_name }}
            body: "Automated build"
-           
-           
-           
-           

--- a/scripts/build-qimgv.sh
+++ b/scripts/build-qimgv.sh
@@ -28,8 +28,8 @@ mkdir -p $BUILD_DIR
 
 # ------------------------------------------------------------------------------
 echo "UPDATING DEPENDENCY LIST"
-wget -O $BUILD_DIR/msys2-build-deps.txt https://raw.githubusercontent.com/easymodo/qimgv-deps-bin/main/msys2-build-deps.txt
-wget -O $BUILD_DIR/msys2-dll-deps.txt https://raw.githubusercontent.com/easymodo/qimgv-deps-bin/main/msys2-dll-deps.txt
+wget --progress=dot:mega -O $BUILD_DIR/msys2-build-deps.txt https://raw.githubusercontent.com/easymodo/qimgv-deps-bin/main/msys2-build-deps.txt
+wget --progress=dot:mega -O $BUILD_DIR/msys2-dll-deps.txt https://raw.githubusercontent.com/easymodo/qimgv-deps-bin/main/msys2-dll-deps.txt
 
 # ------------------------------------------------------------------------------
 echo "INSTALLING MSYS2 BUILD DEPS"
@@ -40,7 +40,7 @@ pacman -S $MSYS_DEPS --noconfirm --needed
 echo "GETTING Qt"
 mkdir C:/qt
 cd C:/qt
-wget -O 5.15.3-mingw64-slim.7z https://github.com/easymodo/qt-builds/releases/download/5.15.3-mingw64-slim/5.15.3-mingw64-slim.7z
+wget --progress=dot:mega -O 5.15.3-mingw64-slim.7z https://github.com/easymodo/qt-builds/releases/download/5.15.3-mingw64-slim/5.15.3-mingw64-slim.7z
 7z x 5.15.3-mingw64-slim.7z -y
 rm 5.15.3-mingw64-slim.7z
 
@@ -48,7 +48,7 @@ rm 5.15.3-mingw64-slim.7z
 echo "GETTING OpenCV"
 mkdir $OPENCV_DIR
 cd $OPENCV_DIR
-wget -O opencv-minimal-4.5.5-x64.7z https://github.com/easymodo/qimgv-deps-bin/releases/download/x64/opencv-minimal-4.5.5-x64.7z
+wget --progress=dot:mega -O opencv-minimal-4.5.5-x64.7z https://github.com/easymodo/qimgv-deps-bin/releases/download/x64/opencv-minimal-4.5.5-x64.7z
 7z x opencv-minimal-4.5.5-x64.7z -y
 rm opencv-minimal-4.5.5-x64.7z
 
@@ -56,7 +56,7 @@ rm opencv-minimal-4.5.5-x64.7z
 echo "GETTING MPV"
 mkdir $MPV_DIR
 cd $MPV_DIR
-wget -O mpv-x64.7z https://github.com/easymodo/qimgv-deps-bin/releases/download/x64/mpv-x86_64-20230402-git-0f13c38.7z
+wget --progress=dot:mega -O mpv-x64.7z https://github.com/easymodo/qimgv-deps-bin/releases/download/x64/mpv-x86_64-20230402-git-0f13c38.7z
 7z x mpv-x64.7z -y
 rm mpv-x64.7z
 


### PR DESCRIPTION
Everything is still the same in the workflow except it's been tidied slightly, the versions of each action have been updated, and the old set-output syntax has been replaced with the new syntax. No more deprecation warnings!

Also, I went ahead and reduced the amount of noise wget makes when downloading. It looks the same still, just not so many lines.