### PR TITLE
Settings toggle for showing dotfiles and windows hidden files

### DIFF
--- a/qimgv/components/directorymanager/directorymanager.cpp
+++ b/qimgv/components/directorymanager/directorymanager.cpp
@@ -325,11 +325,11 @@ void DirectoryManager::addEntriesFromDirectory(std::vector<FSEntry> &entryVec, Q
         QString name = QString::fromStdString(entry.path().filename().generic_string());
 #ifndef Q_OS_WIN32
         // ignore hidden files
-        if(name.startsWith("."))
+        if(settings->skipHiddenFiles() && name.startsWith("."))
             continue;
 #else
         DWORD attributes = GetFileAttributes(entry.path().generic_string().c_str());
-        if(attributes & FILE_ATTRIBUTE_HIDDEN)
+        if(settings->skipHiddenFiles() && attributes & FILE_ATTRIBUTE_HIDDEN)
             continue;
 #endif
         QString path = QString::fromStdString(entry.path().generic_string());

--- a/qimgv/components/directorymanager/directorymanager.cpp
+++ b/qimgv/components/directorymanager/directorymanager.cpp
@@ -325,11 +325,11 @@ void DirectoryManager::addEntriesFromDirectory(std::vector<FSEntry> &entryVec, Q
         QString name = QString::fromStdString(entry.path().filename().generic_string());
 #ifndef Q_OS_WIN32
         // ignore hidden files
-        if(settings->skipHiddenFiles() && name.startsWith("."))
+        if(!settings->showHiddenFiles() && name.startsWith("."))
             continue;
 #else
         DWORD attributes = GetFileAttributes(entry.path().generic_string().c_str());
-        if(settings->skipHiddenFiles() && attributes & FILE_ATTRIBUTE_HIDDEN)
+        if(!settings->showHiddenFiles() && attributes & FILE_ATTRIBUTE_HIDDEN)
             continue;
 #endif
         QString path = QString::fromStdString(entry.path().generic_string());

--- a/qimgv/gui/dialogs/settingsdialog.cpp
+++ b/qimgv/gui/dialogs/settingsdialog.cpp
@@ -193,7 +193,7 @@ void SettingsDialog::readSettings() {
     ui->clickableEdgesCheckBox->setChecked(settings->clickableEdges());
     ui->clickableEdgesVisibleCheckBox->setChecked(settings->clickableEdgesVisible());
     ui->clickableEdgesVisibleCheckBox->setEnabled(settings->clickableEdges());
-    ui->skipHiddenFilesCheckBox->setChecked(settings->skipHiddenFiles());
+    ui->showHiddenFilesCheckBox->setChecked(settings->showHiddenFiles());
 
     if(settings->zoomIndicatorMode() == INDICATOR_ENABLED)
         ui->zoomIndicatorOn->setChecked(true);
@@ -315,7 +315,7 @@ void SettingsDialog::saveSettings() {
     settings->setPanelFullscreenOnly(ui->panelFullscreenOnlyCheckBox->isChecked());
     settings->setSquareThumbnails(ui->squareThumbnailsCheckBox->isChecked());
     settings->setTransparencyGrid(ui->transparencyGridCheckBox->isChecked());
-    settings->setSkipHiddenFiles(ui->skipHiddenFilesCheckBox->isChecked());
+    settings->setShowHiddenFiles(ui->showHiddenFilesCheckBox->isChecked());
     settings->setEnableSmoothScroll(ui->enableSmoothScrollCheckBox->isChecked());
     settings->setUsePreloader(ui->usePreloaderCheckBox->isChecked());
     settings->setUseThumbnailCache(ui->useThumbnailCacheCheckBox->isChecked());

--- a/qimgv/gui/dialogs/settingsdialog.cpp
+++ b/qimgv/gui/dialogs/settingsdialog.cpp
@@ -193,6 +193,7 @@ void SettingsDialog::readSettings() {
     ui->clickableEdgesCheckBox->setChecked(settings->clickableEdges());
     ui->clickableEdgesVisibleCheckBox->setChecked(settings->clickableEdgesVisible());
     ui->clickableEdgesVisibleCheckBox->setEnabled(settings->clickableEdges());
+    ui->skipHiddenFilesCheckBox->setChecked(settings->skipHiddenFiles());
 
     if(settings->zoomIndicatorMode() == INDICATOR_ENABLED)
         ui->zoomIndicatorOn->setChecked(true);
@@ -314,6 +315,7 @@ void SettingsDialog::saveSettings() {
     settings->setPanelFullscreenOnly(ui->panelFullscreenOnlyCheckBox->isChecked());
     settings->setSquareThumbnails(ui->squareThumbnailsCheckBox->isChecked());
     settings->setTransparencyGrid(ui->transparencyGridCheckBox->isChecked());
+    settings->setSkipHiddenFiles(ui->skipHiddenFilesCheckBox->isChecked());
     settings->setEnableSmoothScroll(ui->enableSmoothScrollCheckBox->isChecked());
     settings->setUsePreloader(ui->usePreloaderCheckBox->isChecked());
     settings->setUseThumbnailCache(ui->useThumbnailCacheCheckBox->isChecked());

--- a/qimgv/gui/dialogs/settingsdialog.ui
+++ b/qimgv/gui/dialogs/settingsdialog.ui
@@ -2272,6 +2272,23 @@
                     </property>
                    </widget>
                   </item>
+                  <item>
+                   <widget class="QWidget" name="widget_31" native="true">
+                    <property name="accessibleName">
+                     <string notr="true">SLine</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="skipHiddenFilesCheckBox">
+                    <property name="enabled">
+                     <bool>true</bool>
+                    </property>
+                    <property name="text">
+                     <string>Skip over dotfiles or windows hidden files</string>
+                    </property>
+                   </widget>
+                  </item>
                  </layout>
                 </widget>
                </item>

--- a/qimgv/gui/dialogs/settingsdialog.ui
+++ b/qimgv/gui/dialogs/settingsdialog.ui
@@ -1550,9 +1550,9 @@
                      </widget>
                     </item>
                     <item>
-                     <widget class="QCheckBox" name="skipHiddenFilesCheckBox">
+                     <widget class="QCheckBox" name="showHiddenFilesCheckBox">
                       <property name="text">
-                       <string>Skip over dotfiles and windows hidden files</string>
+                       <string>Show hidden files</string>
                       </property>
                      </widget>
                     </item>

--- a/qimgv/gui/dialogs/settingsdialog.ui
+++ b/qimgv/gui/dialogs/settingsdialog.ui
@@ -2285,7 +2285,7 @@
                      <bool>true</bool>
                     </property>
                     <property name="text">
-                     <string>Skip over dotfiles or windows hidden files</string>
+                     <string>Skip over dotfiles and windows hidden files</string>
                     </property>
                    </widget>
                   </item>

--- a/qimgv/gui/dialogs/settingsdialog.ui
+++ b/qimgv/gui/dialogs/settingsdialog.ui
@@ -1542,6 +1542,20 @@
                       </property>
                      </widget>
                     </item>
+                    <item>
+                     <widget class="QWidget" name="widget_31" native="true">
+                      <property name="accessibleName">
+                       <string notr="true">SLine</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QCheckBox" name="skipHiddenFilesCheckBox">
+                      <property name="text">
+                       <string>Skip over dotfiles and windows hidden files</string>
+                      </property>
+                     </widget>
+                    </item>
                    </layout>
                   </item>
                  </layout>
@@ -2269,23 +2283,6 @@
                     </property>
                     <property name="text">
                      <string>Images smaller than window will be zoomed in</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QWidget" name="widget_31" native="true">
-                    <property name="accessibleName">
-                     <string notr="true">SLine</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QCheckBox" name="skipHiddenFilesCheckBox">
-                    <property name="enabled">
-                     <bool>true</bool>
-                    </property>
-                    <property name="text">
-                     <string>Skip over dotfiles and windows hidden files</string>
                     </property>
                    </widget>
                   </item>

--- a/qimgv/settings.cpp
+++ b/qimgv/settings.cpp
@@ -1176,7 +1176,7 @@ void Settings::setClickableEdgesVisible(bool mode) {
 }
 //------------------------------------------------------------------------------
 bool Settings::skipHiddenFiles() {
-    return settings->settingsConf->value("skipHiddenFiles", false).toBool();
+    return settings->settingsConf->value("skipHiddenFiles", true).toBool();
 }
 
 void Settings::setSkipHiddenFiles(bool mode) {

--- a/qimgv/settings.cpp
+++ b/qimgv/settings.cpp
@@ -1175,10 +1175,10 @@ void Settings::setClickableEdgesVisible(bool mode) {
     settings->settingsConf->setValue("clickableEdgesVisible", mode);
 }
 //------------------------------------------------------------------------------
-bool Settings::skipHiddenFiles() {
-    return settings->settingsConf->value("skipHiddenFiles", true).toBool();
+bool Settings::showHiddenFiles() {
+    return settings->settingsConf->value("showHiddenFiles", false).toBool();
 }
 
-void Settings::setSkipHiddenFiles(bool mode) {
-    settings->settingsConf->setValue("skipHiddenFiles", mode);
+void Settings::setShowHiddenFiles(bool mode) {
+    settings->settingsConf->setValue("showHiddenFiles", mode);
 }

--- a/qimgv/settings.cpp
+++ b/qimgv/settings.cpp
@@ -1174,3 +1174,11 @@ bool Settings::clickableEdgesVisible() {
 void Settings::setClickableEdgesVisible(bool mode) {
     settings->settingsConf->setValue("clickableEdgesVisible", mode);
 }
+//------------------------------------------------------------------------------
+bool Settings::skipHiddenFiles() {
+    return settings->settingsConf->value("skipHiddenFiles", false).toBool();
+}
+
+void Settings::setSkipHiddenFiles(bool mode) {
+    settings->settingsConf->setValue("skipHiddenFiles", mode);
+}

--- a/qimgv/settings.h
+++ b/qimgv/settings.h
@@ -303,8 +303,8 @@ public:
     bool clickableEdgesVisible();
     void setClickableEdgesVisible(bool mode);
 
-    bool skipHiddenFiles();
-    void setSkipHiddenFiles(bool mode);
+    bool showHiddenFiles();
+    void setShowHiddenFiles(bool mode);
 
 private:
     explicit Settings(QObject *parent = nullptr);

--- a/qimgv/settings.h
+++ b/qimgv/settings.h
@@ -303,6 +303,9 @@ public:
     bool clickableEdgesVisible();
     void setClickableEdgesVisible(bool mode);
 
+    bool skipHiddenFiles();
+    void setSkipHiddenFiles(bool mode);
+
 private:
     explicit Settings(QObject *parent = nullptr);
     QSettings *settingsConf, *stateConf, *themeConf;


### PR DESCRIPTION
Toggle is off by default meaning dotfiles and windows hidden files are not shown until the user checks the 'Show hidden files' checkbox.

![Screenshot 2025-02-10 114846](https://github.com/user-attachments/assets/23da866d-e8eb-4154-9791-edbe4516cfbf)
