### PR TITLE
Added handling for qt6 not liking .desktop in setDesktopFileName

### DIFF
--- a/qimgv/main.cpp
+++ b/qimgv/main.cpp
@@ -84,7 +84,12 @@ int main(int argc, char *argv[]) {
     QCoreApplication::setApplicationName("qimgv");
     QCoreApplication::setApplicationVersion(appVersion.toString());
     QApplication::setEffectEnabled(Qt::UI_AnimateCombo, false);
+
+# if (QT_VERSION_MAJOR == 6)
+    QGuiApplication::setDesktopFileName(QCoreApplication::applicationName());
+# else
     QGuiApplication::setDesktopFileName(QCoreApplication::applicationName() + ".desktop");
+#endif
 
     // needed for mpv
 #ifndef _MSC_VER


### PR DESCRIPTION
When running qimgv in an environment with qt6 installed.
The error message:
QGuiApplication::setDesktopFileName: the specified desktop file name ends with .desktop. For compatibility reasons, the .desktop suffix will be removed. Please specify a desktop file name without .desktop suffix
is displayed
https://doc.qt.io/qt-6/qcoreapplication.html#applicationName-prop
https://doc.qt.io/archives/qt-5.15/qcoreapplication.html#applicationName-prop