### PR TITLE
ShortcutBuilder: make A-Z shortcuts layout-aware

### DIFF
--- a/qimgv/shortcutbuilder.cpp
+++ b/qimgv/shortcutbuilder.cpp
@@ -105,6 +105,12 @@ QString ShortcutBuilder::fromEventNativeScanCode(QKeyEvent *event) {
     // You can always just add the same keybind using your alt. layout if it doesnt work.
     QString sequence = inputMap->keys().value(event->nativeScanCode());
 
+    // layout-aware letters
+    int key = event->key();
+    if(key >= Qt::Key_A && key <= Qt::Key_Z) {
+        sequence = QChar(key);
+    }
+
     if(sequence.isEmpty())
         return sequence;
 


### PR DESCRIPTION
Previously, shortcuts were built using a hardcoded scan-code-to-key map that assumed a QWERTY layout.
This caused issues for users with different layouts, such as AZERTY, where keys like 'A' and 'Q' were swapped in keybinds.

This change ensures that keys in the A-Z range use the actual key value provided by the event, making letter-based shortcuts layout-aware. Non-letter keys and non-Latin layouts still fallback to the native scan code map to maintain physical position consistency where appropriate.

edit: fixes #338