### PR TITLE
chore: update workflow actions

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -17,7 +17,7 @@ jobs:
           update: true
           install: git p7zip
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with: 
           #ref: dev
           fetch-depth: 0
@@ -34,7 +34,7 @@ jobs:
           echo "running: 7z a qimgv-x64.7z ./${BUILD_NAME}"
           7z a qimgv-x64.7z ./${BUILD_NAME}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: qimgv-build
           path: qimgv-x64.7z
@@ -48,14 +48,14 @@ jobs:
     needs: build
     steps:
        #- run: echo "${{ needs.build.outputs.build_name }}"
-       - uses: actions/download-artifact@v4
+       - uses: actions/download-artifact@v8
          with: 
            name: qimgv-build
 
        - name: Rename archive
          run: mv qimgv-x64.7z "${{ needs.build.outputs.build_file_name }}"
 
-       - uses: softprops/action-gh-release@v2
+       - uses: softprops/action-gh-release@v3
          #if: startsWith(github.ref, 'refs/tags/')
          with:
            files: ${{ needs.build.outputs.build_file_name }}


### PR DESCRIPTION
In preparation for Node 20 deprecation taking place on September 16, 2026. Here is the message that running the current workflow gives:

**`Warning:`**`Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/upload-artifact@v4, actions/download-artifact@v4, softprops/action-gh-release@v2. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see:`[`https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/`](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners)