### PR TITLE
Add more MimeTypes to qimgv.desktop

### DIFF
--- a/qimgv/distrib/qimgv.desktop
+++ b/qimgv/distrib/qimgv.desktop
@@ -8,5 +8,5 @@ Icon=qimgv
 Terminal=false
 Type=Application
 Categories=Qt;Graphics;Viewer;
-MimeType=video/webm;image/jpeg;image/gif;image/png;image/bmp;image/webp;image/jxl;image/heif;image/avif;image/heif;image/heic;image/x-ico;image/tiff;image/x-exr;
+MimeType=video/webm;image/jpeg;image/gif;image/png;image/bmp;image/webp;image/jxl;image/avif;image/heif;image/heic;image/x-ico;image/tiff;image/x-exr;
 Keywords=image;view;qimgv;picture;gif;jpeg;webm;png;jpg;gallery;

--- a/qimgv/distrib/qimgv.desktop
+++ b/qimgv/distrib/qimgv.desktop
@@ -8,5 +8,5 @@ Icon=qimgv
 Terminal=false
 Type=Application
 Categories=Qt;Graphics;Viewer;
-MimeType=video/webm;image/jpeg;image/gif;image/png;image/bmp;image/webp;image/jxl;image/avif;image/heif;image/heic;image/x-ico;image/tiff;image/x-exr;
+MimeType=inode/directory;video/webm;image/jpeg;image/gif;image/png;image/bmp;image/webp;image/jxl;image/avif;image/heif;image/heic;image/x-ico;image/tiff;image/x-exr;
 Keywords=image;view;qimgv;picture;gif;jpeg;webm;png;jpg;gallery;

--- a/qimgv/distrib/qimgv.desktop
+++ b/qimgv/distrib/qimgv.desktop
@@ -8,5 +8,5 @@ Icon=qimgv
 Terminal=false
 Type=Application
 Categories=Qt;Graphics;Viewer;
-MimeType=video/webm;image/jpeg;image/gif;image/png;image/bmp;image/webp;image/jxl;image/heif;image/avif;image/heif;image/heic;image/x-ico;image/tiff;image/x-exr;image/hdr;
+MimeType=video/webm;image/jpeg;image/gif;image/png;image/bmp;image/webp;image/jxl;image/heif;image/avif;image/heif;image/heic;image/x-ico;image/tiff;image/x-exr;
 Keywords=image;view;qimgv;picture;gif;jpeg;webm;png;jpg;gallery;

--- a/qimgv/distrib/qimgv.desktop
+++ b/qimgv/distrib/qimgv.desktop
@@ -8,5 +8,5 @@ Icon=qimgv
 Terminal=false
 Type=Application
 Categories=Qt;Graphics;Viewer;
-MimeType=video/webm;image/jpeg;image/gif;image/png;image/bmp;image/webp;
-Keywords=image;view;qimgv;picture;gif;jpeg;webm;
+MimeType=video/webm;image/jpeg;image/gif;image/png;image/bmp;image/webp;image/jxl;image/heif;image/avif;image/heif;image/heic;image/x-ico;image/tiff;image/x-exr;image/hdr;
+Keywords=image;view;qimgv;picture;gif;jpeg;webm;png;jpg;gallery;


### PR DESCRIPTION
Added MimeTypes for file formats which qimgv can open. It's useful when choosing an application to open the picture with.
I manually verified that all added MimeTypes belong to file formats qimgv can actually read. 

### Before: 
<img width="666" height="550" alt="1" src="https://github.com/user-attachments/assets/ad763cb6-e47a-45ed-b616-4fb47f8d2bc4" />

### After:
<img width="669" height="578" alt="2" src="https://github.com/user-attachments/assets/4f382bc0-4732-493b-81f1-f4e6c6776424" />
