### PR TITLE
Improvements

### DIFF
--- a/qimgv/components/actionmanager/actionmanager.h
+++ b/qimgv/components/actionmanager/actionmanager.h
@@ -121,7 +121,8 @@ signals:
     void nextDirectory();
     void prevDirectory();
     void lockZoom();
-    void lockView();
+    void togglePreserveView();
+    void togglePreserveCurrentView();
     void print();
     void toggleFullscreenInfoBar();
     void pasteFile();

--- a/qimgv/components/actionmanager/actionmanager.h
+++ b/qimgv/components/actionmanager/actionmanager.h
@@ -78,6 +78,7 @@ signals:
     void zoomOut();
     void zoomInCursor();
     void zoomOutCursor();
+    void zoomInCenterCursor();
     void resize();
     void rotateLeft();
     void rotateRight();

--- a/qimgv/core.cpp
+++ b/qimgv/core.cpp
@@ -147,6 +147,7 @@ void Core::initActions() {
     connect(actionManager, &ActionManager::zoomOut, mw, &MW::zoomOut);
     connect(actionManager, &ActionManager::zoomInCursor, mw, &MW::zoomInCursor);
     connect(actionManager, &ActionManager::zoomOutCursor, mw, &MW::zoomOutCursor);
+    connect(actionManager, &ActionManager::zoomInCenterCursor, mw, &MW::zoomInCenterCursor);
     connect(actionManager, &ActionManager::scrollUp, mw, &MW::scrollUp);
     connect(actionManager, &ActionManager::scrollDown, mw, &MW::scrollDown);
     connect(actionManager, &ActionManager::scrollLeft, mw, &MW::scrollLeft);

--- a/qimgv/core.cpp
+++ b/qimgv/core.cpp
@@ -730,32 +730,39 @@ void Core::showInDirectory() {
         QDesktopServices::openUrl(QUrl::fromLocalFile(model->directoryPath()));
         return;
     }
+    QStringList cmd;
+    
 #if defined(__linux__) || defined(__FreeBSD__)
     QString fm = ScriptManager::runCommand("xdg-mime query default inode/directory");
-    if(fm.contains("dolphin"))
-        ScriptManager::runCommandDetached("dolphin --select " + selectedPath());
-    else if(fm.contains("nautilus"))
-        ScriptManager::runCommandDetached("nautilus --select " + selectedPath());
+    
+    if(fm.contains("dolphin", Qt::CaseInsensitive))
+        cmd << "dolphin" << "--select" << selectedPath();
+    else if(fm.contains("nautilus", Qt::CaseInsensitive))
+        cmd << "nautilus" << "--select" << selectedPath();
+    else if(fm.contains("nemo", Qt::CaseInsensitive))
+        cmd << "nemo" << selectedPath();
     else
         QDesktopServices::openUrl(QUrl::fromLocalFile(model->directoryPath()));
 #elif __WIN32
-    QStringList args;
-    args << "/select," << QDir::toNativeSeparators(selectedPath());
-    QProcess::startDetached("explorer", args);
+    cmd << "explorer" << "/select," << QDir::toNativeSeparators(selectedPath());
 #elif __APPLE__
-    QStringList args;
-    args << "-e";
-    args << "tell application \"Finder\"";
-    args << "-e";
-    args << "activate";
-    args << "-e";
-    args << "select POSIX file \""+selectedPath()+"\"";
-    args << "-e";
-    args << "end tell";
-    QProcess::startDetached("osascript", args);
+    cmd << "osascript";
+    cmd << "-e";
+    cmd << "tell application \"Finder\"";
+    cmd << "-e";
+    cmd << "activate";
+    cmd << "-e";
+    cmd << "select POSIX file \""+selectedPath()+"\"";
+    cmd << "-e";
+    cmd << "end tell";
 #else
     QDesktopServices::openUrl(QUrl::fromLocalFile(model->directoryPath()));
 #endif
+
+    if(!cmd.isEmpty()) {
+        QProcess::startDetached(cmd.takeFirst(), cmd);
+    }
+
 }
 
 void Core::interactiveCopy(QList<QString> paths, QString destDirectory) {

--- a/qimgv/core.cpp
+++ b/qimgv/core.cpp
@@ -142,7 +142,8 @@ void Core::initActions() {
     connect(actionManager, &ActionManager::toggleFitMode, mw, &MW::switchFitMode);
     connect(actionManager, &ActionManager::toggleFullscreen, mw, &MW::triggerFullScreen);
     connect(actionManager, &ActionManager::lockZoom, mw, &MW::toggleLockZoom);
-    connect(actionManager, &ActionManager::lockView, mw, &MW::toggleLockView);
+    connect(actionManager, &ActionManager::togglePreserveView, mw, &MW::togglePreserveView);
+    connect(actionManager, &ActionManager::togglePreserveCurrentView, mw, &MW::togglePreserveCurrentView);
     connect(actionManager, &ActionManager::zoomIn, mw, &MW::zoomIn);
     connect(actionManager, &ActionManager::zoomOut, mw, &MW::zoomOut);
     connect(actionManager, &ActionManager::zoomInCursor, mw, &MW::zoomInCursor);

--- a/qimgv/core.cpp
+++ b/qimgv/core.cpp
@@ -141,7 +141,6 @@ void Core::initActions() {
     connect(actionManager, &ActionManager::fitWindowStretch, mw, &MW::fitWindowStretch);
     connect(actionManager, &ActionManager::toggleFitMode, mw, &MW::switchFitMode);
     connect(actionManager, &ActionManager::toggleFullscreen, mw, &MW::triggerFullScreen);
-    connect(actionManager, &ActionManager::lockZoom, mw, &MW::toggleLockZoom);
     connect(actionManager, &ActionManager::togglePreserveView, mw, &MW::togglePreserveView);
     connect(actionManager, &ActionManager::togglePreserveCurrentView, mw, &MW::togglePreserveCurrentView);
     connect(actionManager, &ActionManager::zoomIn, mw, &MW::zoomIn);

--- a/qimgv/gui/contextmenu.cpp
+++ b/qimgv/gui/contextmenu.cpp
@@ -188,12 +188,10 @@ void ContextMenu::paintEvent(QPaintEvent *event) {
 void ContextMenu::keyPressEvent(QKeyEvent *event) {
     quint32 nativeScanCode = event->nativeScanCode();
     QString key = actionManager->keyForNativeScancode(nativeScanCode);
-    // todo: keyboard navigation
-    if(key == "Up") {}
-    if(key == "Down") {}
-    if(key == "Esc")
+    if(key == "Esc") {
         hide();
-    if(key == "Enter") {}
-    else
-        actionManager->processEvent(event);
+        return;
+    }
+    
+    actionManager->processEvent(event);
 }

--- a/qimgv/gui/dialogs/settingsdialog.cpp
+++ b/qimgv/gui/dialogs/settingsdialog.cpp
@@ -645,10 +645,10 @@ void SettingsDialog::selectMpvPath() {
 }
 //------------------------------------------------------------------------------
 void SettingsDialog::onExpandLimitSliderChanged(int value) {
-    if(value == 0)
-        ui->expandLimitLabel->setText("-");
+    if(value == 4)
+        ui->expandLimitLabel->setText(tr("Maximum"));
     else
-        ui->expandLimitLabel->setText(QString::number(value) + "x");
+        ui->expandLimitLabel->setText(QString::number(value+1) + "x");
 }
 //------------------------------------------------------------------------------
 void SettingsDialog::onJPEGQualitySliderChanged(int value) {

--- a/qimgv/gui/dialogs/settingsdialog.ui
+++ b/qimgv/gui/dialogs/settingsdialog.ui
@@ -2247,7 +2247,7 @@
                          </property>
                          <property name="minimumSize">
                           <size>
-                           <width>35</width>
+                           <width>100</width>
                            <height>0</height>
                           </size>
                          </property>

--- a/qimgv/gui/mainwindow.cpp
+++ b/qimgv/gui/mainwindow.cpp
@@ -295,15 +295,6 @@ void MW::setDirectoryPath(QString path) {
     onInfoUpdated();
 }
 
-void MW::toggleLockZoom() {
-    viewerWidget->toggleLockZoom();
-    if(viewerWidget->lockZoomEnabled())
-        showMessage("Zoom lock: ON");
-    else
-        showMessage("Zoom lock: OFF");
-    onInfoUpdated();
-}
-
 void MW::togglePreserveView() {
     viewerWidget->togglePreserveView();
     if(viewerWidget->preserveViewEnabled())
@@ -844,8 +835,6 @@ void MW::onInfoUpdated() {
             states.append(" [slideshow]");
         if(info.shuffle)
             states.append(" [shuffle]");
-        if(viewerWidget->lockZoomEnabled())
-            states.append(" [zoom lock]");
         if(viewerWidget->preserveViewEnabled() || viewerWidget->preserveCurrentViewEnabled())
             states.append(" [preserved view]");
 

--- a/qimgv/gui/mainwindow.cpp
+++ b/qimgv/gui/mainwindow.cpp
@@ -304,12 +304,21 @@ void MW::toggleLockZoom() {
     onInfoUpdated();
 }
 
-void MW::toggleLockView() {
-    viewerWidget->toggleLockView();
-    if(viewerWidget->lockViewEnabled())
-        showMessage("View lock: ON");
+void MW::togglePreserveView() {
+    viewerWidget->togglePreserveView();
+    if(viewerWidget->preserveViewEnabled())
+        showMessage("Preserve view: ON");
     else
-        showMessage("View lock: OFF");
+        showMessage("Preserve view: OFF");
+    onInfoUpdated();
+}
+
+void MW::togglePreserveCurrentView() {
+    viewerWidget->togglePreserveCurrentView();
+    if(viewerWidget->preserveCurrentViewEnabled())
+        showMessage("Preserve current view: ON");
+    else
+        showMessage("Preserve current view: OFF");
     onInfoUpdated();
 }
 
@@ -837,8 +846,8 @@ void MW::onInfoUpdated() {
             states.append(" [shuffle]");
         if(viewerWidget->lockZoomEnabled())
             states.append(" [zoom lock]");
-        if(viewerWidget->lockViewEnabled())
-            states.append(" [view lock]");
+        if(viewerWidget->preserveViewEnabled() || viewerWidget->preserveCurrentViewEnabled())
+            states.append(" [preserved view]");
 
         if(!settings->infoBarWindowed() && !states.isEmpty())
             windowTitle.append(" -" + states);

--- a/qimgv/gui/mainwindow.cpp
+++ b/qimgv/gui/mainwindow.cpp
@@ -84,6 +84,7 @@ void MW::setupUi() {
     connect(this, &MW::zoomOut,       viewerWidget.get(), &ViewerWidget::zoomOut);
     connect(this, &MW::zoomInCursor,  viewerWidget.get(), &ViewerWidget::zoomInCursor);
     connect(this, &MW::zoomOutCursor, viewerWidget.get(), &ViewerWidget::zoomOutCursor);
+    connect(this, &MW::zoomInCenterCursor,  viewerWidget.get(), &ViewerWidget::zoomInCenterCursor);
     connect(this, &MW::scrollUp,    viewerWidget.get(), &ViewerWidget::scrollUp);
     connect(this, &MW::scrollDown,  viewerWidget.get(), &ViewerWidget::scrollDown);
     connect(this, &MW::scrollLeft,  viewerWidget.get(), &ViewerWidget::scrollLeft);

--- a/qimgv/gui/mainwindow.h
+++ b/qimgv/gui/mainwindow.h
@@ -252,7 +252,6 @@ public slots:
     void setFilter(ScalingFilter filter);
     void toggleScalingFilter();
     void setDirectoryPath(QString path);
-    void toggleLockZoom();
     void togglePreserveView();
     void togglePreserveCurrentView();
     void toggleFullscreenInfoBar();

--- a/qimgv/gui/mainwindow.h
+++ b/qimgv/gui/mainwindow.h
@@ -180,6 +180,7 @@ signals:
     void zoomOut();
     void zoomInCursor();
     void zoomOutCursor();
+    void zoomInCenterCursor();
     void scrollUp();
     void scrollDown();
     void scrollLeft();

--- a/qimgv/gui/mainwindow.h
+++ b/qimgv/gui/mainwindow.h
@@ -253,6 +253,7 @@ public slots:
     void toggleScalingFilter();
     void setDirectoryPath(QString path);
     void toggleLockZoom();
-    void toggleLockView();
+    void togglePreserveView();
+    void togglePreserveCurrentView();
     void toggleFullscreenInfoBar();
 };

--- a/qimgv/gui/viewers/imageviewerv2.cpp
+++ b/qimgv/gui/viewers/imageviewerv2.cpp
@@ -316,8 +316,7 @@ void ImageViewerV2::showAnimation(std::shared_ptr<QMovie> _movie) {
         } else {
             imageFitMode = FIT_FREE;
             fitFree(savedZoomFactor());
-            if(viewPreservationMode != PRESERVE_ZOOM)
-                applySavedViewportPos();
+            applySavedViewportPos();
         }
         startAnimation();
     }
@@ -347,8 +346,7 @@ void ImageViewerV2::showImage(std::unique_ptr<QPixmap> _pixmap) {
         } else {
             imageFitMode = FIT_FREE;
             fitFree(savedZoomFactor());
-            if(viewPreservationMode != PRESERVE_ZOOM)
-                applySavedViewportPos();
+            applySavedViewportPos();
         }
         requestScaling();
         update();
@@ -357,9 +355,6 @@ void ImageViewerV2::showImage(std::unique_ptr<QPixmap> _pixmap) {
 
 // reset state, remove image & stop animation
 void ImageViewerV2::reset() {
-    if(viewPreservationMode == PRESERVE_ZOOM) {
-        saveZoomFactor();
-    }
     if(viewPreservationMode == PRESERVE_VIEW) {
         saveViewportPos();
         saveZoomFactor();
@@ -1354,17 +1349,6 @@ float ImageViewerV2::nextScale(bool zoom_in_or_out) {
     
     qDebug() << "error: unreachable code reached.\n";
     return 1;
-}
-
-void ImageViewerV2::toggleLockZoom() {
-    if(!isDisplaying())
-        return;
-    
-    viewPreservationMode = viewPreservationMode == PRESERVE_ZOOM ? PRESERVE_NONE : PRESERVE_ZOOM;
-}
-
-bool ImageViewerV2::lockZoomEnabled() {
-    return (viewPreservationMode == PRESERVE_ZOOM);
 }
 
 qreal ImageViewerV2::savedZoomFactor() {

--- a/qimgv/gui/viewers/imageviewerv2.cpp
+++ b/qimgv/gui/viewers/imageviewerv2.cpp
@@ -20,7 +20,7 @@ ImageViewerV2::ImageViewerV2(QWidget *parent) : QGraphicsView(parent),
     maxScale(500.0f),
     fitWindowScale(0.125f),
     fitWindowStretchScale(0.125f),
-    mViewLock(LOCK_NONE),
+    viewPreservationMode(PRESERVE_NONE),
     imageFitMode(FIT_WINDOW),
     mScalingFilter(QI_FILTER_BILINEAR),
     imageFitModeDefault(FIT_WINDOW),
@@ -134,6 +134,7 @@ void ImageViewerV2::onDPRChanged() {
 }
 
 void ImageViewerV2::readSettings() {
+    zoomPreservationMode = (ZoomPreservationMode) settings->zoomPreservationMode();
     transparencyGrid = settings->transparencyGrid();
     smoothAnimatedImages = settings->smoothAnimatedImages();
     smoothUpscaling = settings->smoothUpscaling();
@@ -310,12 +311,12 @@ void ImageViewerV2::showAnimation(std::shared_ptr<QMovie> _movie) {
         if(!keepFitMode || imageFitMode == FIT_FREE)
             imageFitMode = imageFitModeDefault;
 
-        if(mViewLock == LOCK_NONE) {
+        if(viewPreservationMode == PRESERVE_NONE) {
             applyFitMode();
         } else {
             imageFitMode = FIT_FREE;
-            fitFree(lockedScale);
-            if(mViewLock == LOCK_ALL)
+            fitFree(savedZoomFactor());
+            if(viewPreservationMode != PRESERVE_ZOOM)
                 applySavedViewportPos();
         }
         startAnimation();
@@ -341,12 +342,12 @@ void ImageViewerV2::showImage(std::unique_ptr<QPixmap> _pixmap) {
         if(!keepFitMode || imageFitMode == FIT_FREE)
             imageFitMode = imageFitModeDefault;
 
-        if(mViewLock == LOCK_NONE) {
+        if(viewPreservationMode == PRESERVE_NONE) {
             applyFitMode();
         } else {
             imageFitMode = FIT_FREE;
-            fitFree(lockedScale);
-            if(mViewLock == LOCK_ALL)
+            fitFree(savedZoomFactor());
+            if(viewPreservationMode != PRESERVE_ZOOM)
                 applySavedViewportPos();
         }
         requestScaling();
@@ -356,6 +357,14 @@ void ImageViewerV2::showImage(std::unique_ptr<QPixmap> _pixmap) {
 
 // reset state, remove image & stop animation
 void ImageViewerV2::reset() {
+    if(viewPreservationMode == PRESERVE_ZOOM) {
+        saveZoomFactor();
+    }
+    if(viewPreservationMode == PRESERVE_VIEW) {
+        saveViewportPos();
+        saveZoomFactor();
+    }
+
     stopPosAnimation();
     pixmapItemScaled.setPixmap(QPixmap());
     pixmapScaled.reset(nullptr);
@@ -701,7 +710,6 @@ void ImageViewerV2::wheelEvent(QWheelEvent *event) {
            event->ignore();
            QWidget::wheelEvent(event);
         }
-        saveViewportPos();
     } else {
         event->ignore();
         QWidget::wheelEvent(event);
@@ -732,7 +740,6 @@ void ImageViewerV2::mousePan(QMouseEvent *event) {
     mouseMoveStartPos -= event->pos();
     scroll(mouseMoveStartPos.x(), mouseMoveStartPos.y(), false);
     mouseMoveStartPos = event->pos();
-    saveViewportPos();
 }
 
 //  zooming while the right button is pressed
@@ -800,8 +807,8 @@ void ImageViewerV2::updateMinScale() {
         else
             minScale = fitWindowScale;
     }
-    if(mViewLock != LOCK_NONE && lockedScale < minScale)
-        minScale = lockedScale;
+    if(viewPreservationMode != PRESERVE_NONE && savedZoomFactor() < minScale)
+        minScale = savedZoomFactor();
 }
 
 void ImageViewerV2::fitWidth() {
@@ -968,7 +975,6 @@ void ImageViewerV2::resizeEvent(QResizeEvent *event) {
         if(scaleTimer->isActive())
             scaleTimer->stop();
         scaleTimer->start();
-        saveViewportPos();
     }
 }
 
@@ -1036,7 +1042,6 @@ void ImageViewerV2::scrollSmooth(int dx, int dy) {
         scrollTimeLineY->setFrameRange(currentYPos, newEndFrame);
         scrollTimeLineY->start();
     }
-    saveViewportPos();
 }
 
 void ImageViewerV2::scrollPrecise(int dx, int dy) {
@@ -1045,7 +1050,6 @@ void ImageViewerV2::scrollPrecise(int dx, int dy) {
     vs->setValue(vs->value() + dy);
     centerIfNecessary();
     snapToEdges();
-    saveViewportPos();
 }
 
 // used by scrollTimeLine
@@ -1067,7 +1071,7 @@ void ImageViewerV2::scrollToY(int y) {
 }
 
 void ImageViewerV2::onScrollTimelineFinished() {
-    saveViewportPos();
+    
 }
 
 void ImageViewerV2::swapToOriginalPixmap() {
@@ -1355,61 +1359,134 @@ float ImageViewerV2::nextScale(bool zoom_in_or_out) {
 void ImageViewerV2::toggleLockZoom() {
     if(!isDisplaying())
         return;
-    if(mViewLock != LOCK_ZOOM) {
-        mViewLock = LOCK_ZOOM;
-        lockZoom();
-    } else {
-        mViewLock = LOCK_NONE;
-    }
+    
+    viewPreservationMode = viewPreservationMode == PRESERVE_ZOOM ? PRESERVE_NONE : PRESERVE_ZOOM;
 }
 
 bool ImageViewerV2::lockZoomEnabled() {
-    return (mViewLock == LOCK_ZOOM);
+    return (viewPreservationMode == PRESERVE_ZOOM);
 }
 
-void ImageViewerV2::lockZoom() {
-    lockedScale = pixmapItem.scale();
-    imageFitMode = FIT_FREE;
-    saveViewportPos();
+qreal ImageViewerV2::savedZoomFactor() {
+    QRectF img_rect_pix = pixmapItem.boundingRect();
+    
+    if(zoomPreservationMode == PRESERVE_IMG_PIXEL_DENSITY) {
+        return savedZoomFactor_;
+    } else if(zoomPreservationMode == PRESERVE_IMG_SCENE_WIDTH) {
+        return savedZoomFactor_ / img_rect_pix.width();
+    } else if(zoomPreservationMode == PRESERVE_IMG_SCENE_HEIGHT) {
+        return savedZoomFactor_ / img_rect_pix.height();
+    }
+    return 1;
 }
 
-void ImageViewerV2::toggleLockView() {
-    if(!isDisplaying())
-        return;
-    if(mViewLock != LOCK_ALL) {
-        mViewLock = LOCK_ALL;
-        lockZoom();
-        saveViewportPos();
-    } else {
-        mViewLock = LOCK_NONE;
+void ImageViewerV2::saveZoomFactor() {
+    /*  To preserve the zoom level ("physical" image size) when switching between two images there are two approaches:
+        (1) Both images have the same logical to physical size ratio. This means a pixel of image A covers the same physical size as a pixel of image B.
+        (2) Both images cover the same physical size (even when image dimensions differ).
+        Approach (1) can be implemented by simply saving and setting the image scale (pixmapItem.scale()) of the next image to the previous image.
+        For Approach (2) we effectively must to preserve the viewport width (or height). The goal is fomalized: img1_vp_width = img2_vp_width
+        Since the scene isn't rotated, sheared or scaled we can assume a constant conversation factor between viewport and scene:
+        vp_width = scene_width*C => img1_scene_width*C = img2_scene_width*C => img1_scene_width = img2_scene_width
+        The QGraphicsPixmapItem does not have any unusual transformations applied so we ASSUME:
+        img_scene_width = img_width * img_scaling_factor => img1_width * img1_scaling_factor = img2_width * img2_scaling_factor
+        => img2_scaling_factor = (img1_width * img1_scaling_factor) / img2_width
+    */
+    
+    QRectF img_rect_pix = pixmapItem.boundingRect();
+    
+    if(zoomPreservationMode == PRESERVE_IMG_PIXEL_DENSITY) { // (1)
+        savedZoomFactor_ = pixmapItem.scale();
+    } else if(zoomPreservationMode == PRESERVE_IMG_SCENE_WIDTH) { // (2)
+        savedZoomFactor_ = pixmapItem.scale() * img_rect_pix.width();
+    } else if(zoomPreservationMode == PRESERVE_IMG_SCENE_HEIGHT) { // (2)
+        savedZoomFactor_ = pixmapItem.scale() * img_rect_pix.height();
     }
 }
 
-bool ImageViewerV2::lockViewEnabled() {
-    return (mViewLock == LOCK_ALL);
+void ImageViewerV2::togglePreserveCurrentView() {
+    if(!isDisplaying())
+        return;
+
+    viewPreservationMode = viewPreservationMode == PRESERVE_CURRENT_VIEW ? PRESERVE_NONE : PRESERVE_CURRENT_VIEW;
+    if(viewPreservationMode == PRESERVE_CURRENT_VIEW) {
+        saveZoomFactor();
+        saveViewportPos();
+    }
 }
 
-// savedViewportPos is [0...1][0...1]
-// values are where viewport center is on the image
-void ImageViewerV2::saveViewportPos() {
-    if(mViewLock != LOCK_ALL)
+void ImageViewerV2::togglePreserveView() {
+    if(!isDisplaying())
         return;
-    QGraphicsPixmapItem *item = &pixmapItem;
-    QPointF sceneCenter = mapToScene( viewport()->rect().center() ) + QPointF(1,1);
-    auto itemRect = item->sceneBoundingRect();
-    savedViewportPos.setX(qBound(qreal(0), (sceneCenter.x() - itemRect.left()) / itemRect.width(),  qreal(1)));
-    savedViewportPos.setY(qBound(qreal(0), (sceneCenter.y() - itemRect.top())  / itemRect.height(), qreal(1)));
+    
+     viewPreservationMode = viewPreservationMode == PRESERVE_VIEW ? PRESERVE_NONE : PRESERVE_VIEW;
+}
+
+bool ImageViewerV2::preserveViewEnabled() {
+    return (viewPreservationMode == PRESERVE_VIEW);
+}
+
+bool ImageViewerV2::preserveCurrentViewEnabled() {
+    return (viewPreservationMode == PRESERVE_CURRENT_VIEW);
+}
+
+void ImageViewerV2::saveViewportPos() {
+    /*  To preserve the relative view when switching to another image means:
+        When the viewport is currently in a corner (bounded by two image borders) and the user switches to another image, the new viewport must be located in the same corner.
+        Everything in between must be interpolated.
+        For that, we have to calculate the viewport relative to the image's rect.
+        Since the viewport is a rect itself (rect relative to rect) we'll take the viewport's center relative to the "inner box".
+        The inner box is a rect defined by all possible positions where the viewport's center can be when scrolling/moving the image.
+        Its top-left corner is at img_rect.topLeft() + viewport_dim/2 and its bottom-right corner at img_rect.bottomRight() - viewport_dim/2
+        The exception is when the image is smaller than the viewport. In that case the viewport's center can only be at the image's center.
+    */
+    
+    
+    QRectF viewport_rect = mapToScene(viewport()->rect()).boundingRect();
+    QPointF top_left_viewport = viewport_rect.topLeft();
+    QPointF viewport_dim = QPointF(viewport_rect.width(), viewport_rect.height());
+    
+    QRectF img_rect = pixmapItem.sceneBoundingRect();
+    QRect img_rect_vp = viewportTransform().mapRect(img_rect).toRect();
+    QPointF img_dim = QPointF(img_rect.width(), img_rect.height());
+    QPointF inner_box_dim = img_dim - viewport_dim;
+    QPointF vp_abs_pos_inner_box = top_left_viewport - img_rect.topLeft();
+    
+    QPointF bottom_right_img_vp = mapFromScene(img_rect.bottomRight());
+    bool right_border_collapse = viewport()->width() == bottom_right_img_vp.x();
+    bool bottom_border_collapse = viewport()->height() == bottom_right_img_vp.y();
+    bool img_bigger_viewport_x = viewport()->width() < img_rect_vp.width();
+    bool img_bigger_viewport_y = viewport()->height() < img_rect_vp.height();
+    
+    qreal vp_rel_pos_inner_box_x = !img_bigger_viewport_x ? 0.5 :
+        right_border_collapse ? 1 : vp_abs_pos_inner_box.x() / inner_box_dim.x();
+    qreal vp_rel_pos_inner_box_y = !img_bigger_viewport_y ? 0.5 :
+        bottom_border_collapse ? 1 : vp_abs_pos_inner_box.y() / inner_box_dim.y();
+    
+    // savedViewportPos is (0...1, 0...1) indicating where the viewport center is on the image
+    savedViewportPos.rx() = vp_rel_pos_inner_box_x;
+    savedViewportPos.ry() = vp_rel_pos_inner_box_y;
 }
 
 void ImageViewerV2::applySavedViewportPos() {
-    QGraphicsPixmapItem *item = &pixmapItem;
-    auto itemRect = item->sceneBoundingRect();
-    QPointF newScenePos;
-    newScenePos.setX(itemRect.left() + itemRect.width()  * savedViewportPos.x());
-    newScenePos.setY(itemRect.top()  + itemRect.height() * savedViewportPos.y());
-    centerOn(newScenePos);
-    centerIfNecessary();
-    snapToEdges();
+    QRectF viewport_rect = mapToScene(viewport()->rect()).boundingRect();
+    QPointF viewport_dim = QPointF(viewport_rect.width(), viewport_rect.height());
+    
+    QRectF img_rect = pixmapItem.sceneBoundingRect();
+    QPointF img_dim = QPointF(img_rect.width(), img_rect.height());
+    QPointF inner_box_dim = img_dim - viewport_dim;
+    QPointF top_left_inner_box = img_rect.topLeft() + viewport_dim/2;
+    
+    qreal viewport_center_x = inner_box_dim.x() > 0 ?
+        savedViewportPos.x() * inner_box_dim.x() + top_left_inner_box.x() : img_rect.center().x();
+    
+    qreal viewport_center_y = inner_box_dim.y() > 0 ?
+        savedViewportPos.y() * inner_box_dim.y() + top_left_inner_box.y() : img_rect.center().y();
+    
+    // Again, sceneRoundPos fixes every position drift. MAGIC!
+    QPointF viewport_center = sceneRoundPos(QPointF(viewport_center_x, viewport_center_y));
+    
+    centerOn(viewport_center);
 }
 
 // If the image is smaller than the viewport, center it

--- a/qimgv/gui/viewers/imageviewerv2.cpp
+++ b/qimgv/gui/viewers/imageviewerv2.cpp
@@ -67,9 +67,12 @@ ImageViewerV2::ImageViewerV2(QWidget *parent) : QGraphicsView(parent),
     pixmapItem.setScale(1.0f);
     pixmapItem.setOffset(10000, 10000);
     pixmapItem.setTransformOriginPoint(10000, 10000);
+    // setShapeMode influences pixmapItem.isUnderMouse(). Transparent image areas are now considered part of the pixmap.
+    pixmapItem.setShapeMode(QGraphicsPixmapItem::BoundingRectShape);
     pixmapItemScaled.setScale(1.0f);
     pixmapItemScaled.setOffset(10000, 10000);
     pixmapItemScaled.setTransformOriginPoint(10000, 10000);
+    pixmapItemScaled.setShapeMode(QGraphicsPixmapItem::BoundingRectShape);
 
     this->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     this->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
@@ -525,9 +528,14 @@ void ImageViewerV2::mousePressEvent(QMouseEvent *event) {
 
 void ImageViewerV2::mouseMoveEvent(QMouseEvent *event) {
     QWidget::mouseMoveEvent(event);
-    if(!pixmap || mouseInteraction == MouseInteractionState::MOUSE_DRAG || mouseInteraction == MouseInteractionState::MOUSE_WHEEL_ZOOM)
+    if(!pixmap)
         return;
-
+    
+    zoomCursorPosition.rx() = -1.0;
+    
+    if(mouseInteraction == MouseInteractionState::MOUSE_DRAG || mouseInteraction == MouseInteractionState::MOUSE_WHEEL_ZOOM)
+        return;
+    
     if(event->buttons() & Qt::LeftButton) {
         // ---------------- DRAG / PAN -------------------
         // select which action to start
@@ -1077,21 +1085,120 @@ void ImageViewerV2::zoomAnchored(float newScale) {
     }
 }
 
-// zoom in around viewport center
+// zoom into viewport center
 void ImageViewerV2::zoomIn() {
-    doZoomIn(false);
+    doZoomIn(false, false);
 }
 
-// zoom in around cursor if its inside window
+// zoom in and and ensure that the pixel hovered by the mouse stays exactly on the same screen position
 void ImageViewerV2::zoomInCursor() {
-    doZoomIn(true);
+    doZoomIn(true, false);
 }
 
-void ImageViewerV2::doZoomIn(bool atCursor) {
-    if(atCursor && underMouse())
-        setZoomAnchor(mapFromGlobal(cursor().pos()));
-    else
-        setZoomAnchor(viewport()->rect().center());
+// zoom in and eventually center the pixel that was originally hovered the last time the mouse moved
+void ImageViewerV2::zoomInCenterCursor() {
+    doZoomIn(true, true);
+}
+
+
+QPointF ImageViewerV2::zoomBoxCenterCursor(float zoom_factor) {
+    QRectF viewport_rect = mapToScene(viewport()->rect()).boundingRect();
+    
+    QPointF top_left_viewport_pix = pixmapItem.mapFromScene(viewport_rect.topLeft());
+    QPointF bottom_right_viewport_pix = pixmapItem.mapFromScene(viewport_rect.bottomRight());
+    
+    QRectF img_rect_pix = pixmapItem.boundingRect();
+    QRectF img_rect = pixmapItem.sceneBoundingRect();
+    
+    /* For whatever reason viewport_rect.bottomRight() doesn't exactly match img_rect.bottomRight() when the image's bottom right corner
+       matches the viewport's bottom right corner (the image was moved to the most bottom right position via dragging/scrolling).
+       The cool thing is that when converting the scene coordinates into viewport coordinates they perfectly match in this case. The following
+       is a fix that when the viewport coordinates match, the scene coordinates of img_rect.bottomRight() are always used instead of
+       viewport_rect.bottomRight(). This fixes the slight drift away from the image border when zooming in on the right/bottom side of the image.
+    */
+    QPointF bottom_right_img_vp = mapFromScene(img_rect.bottomRight());
+    bool right_border_collapse = viewport()->width() == bottom_right_img_vp.x();
+    bool bottom_border_collapse = viewport()->height() == bottom_right_img_vp.y();
+    
+    /* When the image's width is smaller than the viewport's width, choose the image's left and right border,
+       otherwise the viewport's left and right border. When the image's height is smaller than the viewport's height,
+       choose the image's top and bottom border, otherwise the viewport's top and bottom border.
+    */
+    QPointF top_left_viewport_or_picture = QPointF(
+        qMax(img_rect.left(), viewport_rect.left()),
+        qMax(img_rect.top(), viewport_rect.top()));
+    QPointF bottom_right_viewport_or_picture = QPointF(
+        right_border_collapse ? img_rect.right() : qMin(img_rect.right(), viewport_rect.right()),
+        bottom_border_collapse ? img_rect.bottom() : qMin(img_rect.bottom(), viewport_rect.bottom()));
+    
+    QPointF top_left_viewport_or_picture_pix = pixmapItem.mapFromScene(top_left_viewport_or_picture);
+    QPointF bottom_right_viewport_or_picture_pix = pixmapItem.mapFromScene(bottom_right_viewport_or_picture);
+    
+    // The zoom box is the viewport after the zoom operation
+    qreal viewport_width_pix = bottom_right_viewport_pix.x() - top_left_viewport_pix.x();
+    qreal zoom_box_width_pix = viewport_width_pix/zoom_factor;
+    qreal half_zoom_box_width_pix = zoom_box_width_pix/2;
+    
+    qreal viewport_height_pix = bottom_right_viewport_pix.y() - top_left_viewport_pix.y();
+    qreal zoom_box_height_pix = viewport_height_pix/zoom_factor;
+    qreal half_zoom_box_height_pix = zoom_box_height_pix/2;
+    
+    qreal cursor_minimum_x_pix = top_left_viewport_or_picture_pix.x()+half_zoom_box_width_pix;
+    qreal cursor_maximum_x_pix = bottom_right_viewport_or_picture_pix.x()-half_zoom_box_width_pix;
+    
+    qreal cursor_minimum_y_pix = top_left_viewport_or_picture_pix.y()+half_zoom_box_height_pix;
+    qreal cursor_maximum_y_pix = bottom_right_viewport_or_picture_pix.y()-half_zoom_box_height_pix;
+    
+    // zoom_box_width_pix >= img_rect_pix.width() is pretty much identical with cursor_minimum_x_pix >= cursor_maximum_x_pix
+    qreal new_zoom_box_x_pix = zoom_box_width_pix >= img_rect_pix.width() ?
+        img_rect_pix.center().x() :
+        qBound(cursor_minimum_x_pix, zoomCursorPosition.x(), cursor_maximum_x_pix);
+    
+    qreal new_zoom_box_y_pix = zoom_box_height_pix >= img_rect_pix.height() ?
+        img_rect_pix.center().y() :
+        qBound(cursor_minimum_y_pix, zoomCursorPosition.y(), cursor_maximum_y_pix);
+    
+    return QPointF(new_zoom_box_x_pix, new_zoom_box_y_pix);
+}
+
+
+void ImageViewerV2::doZoomInCenterCursor(float new_scale) {
+    new_scale = qMin(new_scale, maxScale);
+    float current_scale = pixmapItem.scale();
+    if(!pixmapItem.isUnderMouse() || current_scale == new_scale) return;
+    
+    if(zoomCursorPosition.x() == -1.0 /*indicates that the cursor moved since last function call*/) {
+        QPoint cursor_screen = cursor().pos();
+        QPoint cursor_viewport = viewport()->mapFromGlobal(cursor_screen);
+        QPointF cursor = mapToScene(cursor_viewport);
+        // Cannot contain negative x coordinate because isUnderMouse() blocks this case.
+        zoomCursorPosition = pixmapItem.mapFromScene(cursor);
+    }
+    
+    float zoom_factor = new_scale / current_scale;
+    
+    QPointF zoom_box_center_pix = zoomBoxCenterCursor(zoom_factor);
+    
+    doZoom(new_scale);
+    
+    QPointF zoom_box_center = pixmapItem.mapToScene(zoom_box_center_pix);
+    
+    /* This increases the accuracy of the zoom SO MUCH
+       I was very disappointed that for some reason the zoom had a terrible accuracy and began to hate Qt for it
+       BUT THIS FIXES IT COMPLETELY. IT'S MAGIC!
+    */
+    zoom_box_center = sceneRoundPos(zoom_box_center);
+    
+    centerOn(zoom_box_center);
+    
+    requestScaling();
+}
+
+
+
+
+
+void ImageViewerV2::doZoomIn(bool atCursor, bool pullCenter) {
     float newScale = currentScale() * (1.0f + zoomStep);
     if(useFixedZoomLevels && zoomLevels.count()) {
         if(currentScale() < zoomLevels.first()) {
@@ -1108,9 +1215,22 @@ void ImageViewerV2::doZoomIn(bool atCursor) {
             }
         }
     }
-    zoomAnchored(newScale);
-    centerIfNecessary();
-    snapToEdges();
+    
+    
+    // if the cursor isn't over the picture, fallback to other zoom
+    if(pullCenter && pixmapItem.isUnderMouse()) {
+        doZoomInCenterCursor(newScale);
+    } else if(atCursor && underMouse()) {
+        setZoomAnchor(mapFromGlobal(cursor().pos()));
+        zoomAnchored(newScale);
+        centerIfNecessary();
+        snapToEdges();
+    } else {
+        setZoomAnchor(viewport()->rect().center());
+        zoomAnchored(newScale);
+        centerIfNecessary();
+    }
+    
     imageFitMode = FIT_FREE;
     if(pixmapItem.scale() == fitWindowScale)
         imageFitMode = FIT_WINDOW;
@@ -1129,10 +1249,6 @@ void ImageViewerV2::zoomOutCursor() {
 }
 
 void ImageViewerV2::doZoomOut(bool atCursor) {
-    if(atCursor && underMouse())
-        setZoomAnchor(mapFromGlobal(cursor().pos()));
-    else
-        setZoomAnchor(viewport()->rect().center());
     float newScale = currentScale() * (1.0f - zoomStep);
     if(useFixedZoomLevels && zoomLevels.count()) {
         if(currentScale() > zoomLevels.last()) {
@@ -1149,6 +1265,12 @@ void ImageViewerV2::doZoomOut(bool atCursor) {
             }
         }
     }
+    
+    if(atCursor && underMouse())
+        setZoomAnchor(mapFromGlobal(cursor().pos()));
+    else
+        setZoomAnchor(viewport()->rect().center());
+    
     zoomAnchored(newScale);
     centerIfNecessary();
     snapToEdges();
@@ -1219,6 +1341,7 @@ void ImageViewerV2::applySavedViewportPos() {
     snapToEdges();
 }
 
+// If the image is smaller than the viewport, center it
 void ImageViewerV2::centerIfNecessary() {
     if(!pixmap)
         return;
@@ -1231,6 +1354,7 @@ void ImageViewerV2::centerIfNecessary() {
         vs->setValue(pixmapItem.offset().y() - (int)(vport.height() - imgRect.height()) / 2);
 }
 
+// Ensures that the user can't move past the image's borders, except when the image is smaller than the viewport
 void ImageViewerV2::snapToEdges() {
     QRect imgRect = scaledRectR();
     // current vport center

--- a/qimgv/gui/viewers/imageviewerv2.cpp
+++ b/qimgv/gui/viewers/imageviewerv2.cpp
@@ -78,7 +78,6 @@ ImageViewerV2::ImageViewerV2(QWidget *parent) : QGraphicsView(parent),
     this->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
     scene = new QGraphicsScene();
-    scene->setSceneRect(0,0,200000,200000);
     scene->setBackgroundBrush(QColor(60,60,103));
     scene->addItem(&pixmapItem);
     scene->addItem(&pixmapItemScaled);
@@ -123,6 +122,7 @@ void ImageViewerV2::onDPRChanged() {
     if(pixmap) {
         pixmap->setDevicePixelRatio(dpr);
         pixmapItem.setPixmap(*pixmap);
+        updateSceneRect();
         pixmapItem.show();
         pixmapItem.update();
         updateMinScale();
@@ -281,6 +281,7 @@ void ImageViewerV2::updatePixmap(std::unique_ptr<QPixmap> newPixmap) {
     pixmap = std::move(newPixmap);
     pixmap->setDevicePixelRatio(dpr);
     pixmapItem.setPixmap(*pixmap);
+    updateSceneRect();
     pixmapItem.show();
     pixmapItem.update();
 }
@@ -322,6 +323,7 @@ void ImageViewerV2::showImage(std::unique_ptr<QPixmap> _pixmap) {
         pixmap = std::move(_pixmap);
         pixmap->setDevicePixelRatio(dpr);
         pixmapItem.setPixmap(*pixmap);
+        updateSceneRect();
         Qt::TransformationMode mode = Qt::SmoothTransformation;
         if(mScalingFilter == QI_FILTER_NEAREST)
             mode = Qt::FastTransformation;
@@ -351,6 +353,7 @@ void ImageViewerV2::reset() {
     pixmapItemScaled.setPixmap(QPixmap());
     pixmapScaled.reset(nullptr);
     pixmapItem.setPixmap(QPixmap());
+    updateSceneRect();
     pixmapItem.setScale(1.0f);
     pixmapItem.setOffset(10000,10000);
     pixmap.reset();
@@ -940,6 +943,7 @@ void ImageViewerV2::setFitWindowStretch() {
 
 void ImageViewerV2::resizeEvent(QResizeEvent *event) {
     QGraphicsView::resizeEvent(event);
+    updateSceneRect(true);
     // reset this so we won't generate unnecessary drag'n'drop event
     mousePressPos = mapFromGlobal(cursor().pos());
     // Qt emits some unnecessary resizeEvents on startup
@@ -1066,6 +1070,50 @@ void ImageViewerV2::swapToOriginalPixmap() {
     pixmapItemScaled.setPixmap(QPixmap());
     pixmapScaled.reset(nullptr);
     pixmapItem.show();
+}
+
+
+// This function updates the scene size so that the view is able to move to any relevant point of the image.
+// It must therefore be called whenever the image or viewport/screen dimensions change.
+void ImageViewerV2::updateSceneRect(bool called_by_resize_event) {
+    /*  The scene must be big enough to
+        1. contain the bottom right point of the pixmapItem when it is scaled (zoomed) to the maximum in scene coordinates
+        2. display the center point of the pixmapItem when it is scaled to the maximum at the center of the viewport
+        When an image is very small (1x1 or similar) and scaled to the maximum, requirement 1 will create a scene too small for the image to be actually centered, that's why requirement 2 is needed. pixmapItemScaled is not relevant because it has the same size as pixmapItem.
+    */
+    
+    if(!screen()) {
+        qDebug() << "ImageViewerV2: screen() is null.\n";
+        return;
+    }
+    
+    // Use screen dimensions, not viewport dimensions because they are available way earlier than (correct) viewport coordinates
+    // and the screen rect doesn't have to be updated for every single pixel the window resizes.
+    QRect screen_rect_screen = screen()->geometry();
+    QRectF screen_rect = mapToScene(screen_rect_screen).boundingRect();
+    
+    if(called_by_resize_event) {
+        if(screenDimensions == screen_rect_screen.size())
+            return;
+        
+        screenDimensions = screen_rect_screen.size();
+    }
+    
+    QPointF img_offset = pixmapItem.mapToScene(pixmapItem.offset());
+    
+    // Since there are no unusual transformations applied to the scene or the image, this code ASSUMES that
+    // pixmapItem.boundingRect().width()*pixmapItem.scale() == pixmapItem.sceneBoundingRect().width()
+    qreal max_img_width = pixmapItem.boundingRect().width()*maxScale;
+    qreal max_img_height = pixmapItem.boundingRect().height()*maxScale;
+    
+    // requirement 1: max_img_width/2           requirement 2: screen_rect.width()/2
+    qreal new_scene_width = img_offset.x() + max_img_width/2 +
+        qMax(max_img_width/2, screen_rect.width()/2);
+    
+    qreal new_scene_height = img_offset.y() + max_img_height/2 +
+        qMax(max_img_height/2, screen_rect.height()/2);
+    
+    scene->setSceneRect(0, 0, new_scene_width, new_scene_height);
 }
 
 void ImageViewerV2::setZoomAnchor(QPoint viewportPos) {
@@ -1379,12 +1427,13 @@ void ImageViewerV2::snapToEdges() {
 void ImageViewerV2::doZoom(float newScale) {
     if(!pixmap)
         return;
-    newScale = qBound(minScale, newScale, 500.0f);
+    
+    newScale = qBound(minScale, newScale, maxScale);
     // fix scene position to integer values
     auto tl = pixmapItem.sceneBoundingRect().topLeft().toPoint();
     pixmapItem.setOffset(tl);
     pixmapItem.setScale(newScale);
-
+    
     pixmapItem.setTransformationMode(selectTransformationMode());
     swapToOriginalPixmap();
     emit scaleChanged(newScale);

--- a/qimgv/gui/viewers/imageviewerv2.cpp
+++ b/qimgv/gui/viewers/imageviewerv2.cpp
@@ -139,9 +139,7 @@ void ImageViewerV2::readSettings() {
     smoothAnimatedImages = settings->smoothAnimatedImages();
     smoothUpscaling = settings->smoothUpscaling();
     expandImage = settings->expandImage();
-    expandLimit = static_cast<float>(settings->expandLimit());
-    if(expandLimit < 1.0f)
-        expandLimit = maxScale;
+    expandLimit = settings->expandLimit() == 4 ? maxScale : static_cast<float>(settings->expandLimit()+1);
     keepFitMode = settings->keepFitMode();
     imageFitModeDefault = settings->imageFitMode();
     zoomStep = settings->zoomStep();

--- a/qimgv/gui/viewers/imageviewerv2.cpp
+++ b/qimgv/gui/viewers/imageviewerv2.cpp
@@ -78,6 +78,7 @@ ImageViewerV2::ImageViewerV2(QWidget *parent) : QGraphicsView(parent),
     this->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
     scene = new QGraphicsScene();
+    scene->setItemIndexMethod(QGraphicsScene::NoIndex);
     scene->setBackgroundBrush(QColor(60,60,103));
     scene->addItem(&pixmapItem);
     scene->addItem(&pixmapItemScaled);
@@ -145,12 +146,17 @@ void ImageViewerV2::readSettings() {
     zoomStep = settings->zoomStep();
     focusIn1to1 = settings->focusPointIn1to1Mode();
     trackpadDetection = settings->trackpadDetection();
-    if( (useFixedZoomLevels = settings->useFixedZoomLevels()) ) {
-        // zoomlevels are stored as a string, parse into list
-        zoomLevels.clear();
-        auto levelsStr = settings->zoomLevels().split(',');
-        for(const auto& i : levelsStr)
-            zoomLevels.append(i.toFloat());
+    zoomLevels.clear();
+    useFixedZoomLevels = settings->useFixedZoomLevels();
+    
+    if(useFixedZoomLevels) {
+        QStringList levelsStr = settings->zoomLevels().split(',');
+        for(const QString& nrStr : levelsStr) {
+            bool success = false;
+            float nr = nrStr.toFloat(&success);
+            if(success)
+                zoomLevels.append(nr);
+        }
         std::sort(zoomLevels.begin(), zoomLevels.end());
     }
     // set bg color
@@ -179,7 +185,8 @@ void ImageViewerV2::startAnimation() {
         emit animationPaused(false);
         //movie->jumpToFrame(0);
         //emit frameChanged(0);
-        animationTimer->start(movie->nextFrameDelay());
+        // 1000/60*1.5: Ensures that every image frame gets at least one screen frame of time (60Hz)
+        animationTimer->start(qMax(static_cast<int>(1000.0/60.0*1.5), movie->nextFrameDelay()));
     }
 }
 
@@ -834,7 +841,7 @@ void ImageViewerV2::fitWindow() {
         // - unless when called from eventloop
         if(scrollBarWorkaround) {
             scrollBarWorkaround = false;
-            QTimer::singleShot(0, this, SLOT(centerOnPixmap()));
+            QTimer::singleShot(0, this, &ImageViewerV2::centerOnPixmap);
         } else {
             centerOnPixmap();
         }
@@ -860,7 +867,7 @@ void ImageViewerV2::fitWindowStretch() {
     // Handle scrollbar workaround similar to fitWindow()
     if(scrollBarWorkaround) {
         scrollBarWorkaround = false;
-        QTimer::singleShot(0, this, SLOT(centerOnPixmap()));
+        QTimer::singleShot(0, this, &ImageViewerV2::centerOnPixmap);
     } else {
         centerOnPixmap();
     }
@@ -966,8 +973,8 @@ void ImageViewerV2::resizeEvent(QResizeEvent *event) {
 }
 
 void ImageViewerV2::centerOnPixmap() {
-    auto imgRect = pixmapItem.sceneBoundingRect();
-    auto vport = mapToScene(viewport()->geometry()).boundingRect();
+    QRectF imgRect = pixmapItem.sceneBoundingRect();
+    QRectF vport = mapToScene(viewport()->geometry()).boundingRect();
     hs->setValue(pixmapItem.offset().x() - (int)(vport.width()  - imgRect.width())  / 2);
     vs->setValue(pixmapItem.offset().y() - (int)(vport.height() - imgRect.height()) / 2);
 }
@@ -1122,15 +1129,16 @@ void ImageViewerV2::setZoomAnchor(QPoint viewportPos) {
 }
 
 void ImageViewerV2::zoomAnchored(float newScale) {
-    if(currentScale() != newScale) {
-        QPointF vportCenter = mapToScene(viewport()->geometry()).boundingRect().center();
-        doZoom(newScale);
-        // calculate shift to adjust viewport center
-        // we do this in viewport coordinates to avoid any rounding errors
-        QPointF diff = zoomAnchor.second - mapFromScene(pixmapItem.mapToScene(zoomAnchor.first));
-        centerOn(vportCenter - diff);
-        requestScaling();
-    }
+    if(currentScale() == newScale)
+        return;
+    
+    QPointF vportCenter = mapToScene(viewport()->geometry()).boundingRect().center();
+    doZoom(newScale);
+    // calculate shift to adjust viewport center
+    // we do this in viewport coordinates to avoid any rounding errors
+    QPointF diff = zoomAnchor.second - mapFromScene(pixmapItem.mapToScene(zoomAnchor.first));
+    centerOn(vportCenter - diff);
+    requestScaling();
 }
 
 // zoom into viewport center
@@ -1394,8 +1402,8 @@ void ImageViewerV2::centerIfNecessary() {
     if(!pixmap)
         return;
     QSize sz = scaledSizeR();
-    auto imgRect = pixmapItem.sceneBoundingRect();
-    auto vport = mapToScene(viewport()->geometry()).boundingRect();
+    QRectF imgRect = pixmapItem.sceneBoundingRect();
+    QRectF vport = mapToScene(viewport()->geometry()).boundingRect();
     if(sz.width() <= viewport()->width())
         hs->setValue(pixmapItem.offset().x() - (int)(vport.width()  - imgRect.width())  / 2);
     if(sz.height() <= viewport()->height())
@@ -1430,7 +1438,7 @@ void ImageViewerV2::doZoom(float newScale) {
     
     newScale = qBound(minScale, newScale, maxScale);
     // fix scene position to integer values
-    auto tl = pixmapItem.sceneBoundingRect().topLeft().toPoint();
+    QPoint tl = pixmapItem.sceneBoundingRect().topLeft().toPoint();
     pixmapItem.setOffset(tl);
     pixmapItem.setScale(newScale);
     
@@ -1451,7 +1459,6 @@ QPointF ImageViewerV2::sceneRoundPos(QPointF scenePoint) const {
 // rounds a rect in scene coordinates so it stays on the same spot on viewport
 // the result is what's actually drawn on screen (incl. size)
 QRectF ImageViewerV2::sceneRoundRect(QRectF sceneRect) const {
-    QRectF rounded = QRectF(sceneRoundPos(sceneRect.topLeft()), sceneRect.size());
     return QRectF(sceneRoundPos(sceneRect.topLeft()), sceneRect.size());
 }
 
@@ -1459,15 +1466,12 @@ QRectF ImageViewerV2::sceneRoundRect(QRectF sceneRect) const {
 QSize ImageViewerV2::scaledSizeR() const {
     if(!pixmap)
         return QSize(0,0);
-    QRectF pixmapSceneRect = pixmapItem.mapRectToScene(pixmapItem.boundingRect());
-    return sceneRoundRect(pixmapSceneRect).size().toSize();
+    return sceneRoundRect(pixmapItem.sceneBoundingRect()).size().toSize();
 }
 
 // in viewport coords (rounded up)
 QRect ImageViewerV2::scaledRectR() const {
-    QRectF pixmapSceneRect = pixmapItem.mapRectToScene(pixmapItem.boundingRect());
-    return QRect(mapFromScene(pixmapSceneRect.topLeft()),
-                 mapFromScene(pixmapSceneRect.bottomRight()));
+    return mapFromScene(pixmapItem.sceneBoundingRect()).boundingRect();
 }
 
 float ImageViewerV2::currentScale() const {

--- a/qimgv/gui/viewers/imageviewerv2.cpp
+++ b/qimgv/gui/viewers/imageviewerv2.cpp
@@ -1219,7 +1219,6 @@ QPointF ImageViewerV2::zoomBoxCenterCursor(float zoom_factor) {
 
 
 void ImageViewerV2::doZoomInCenterCursor(float new_scale) {
-    new_scale = qMin(new_scale, maxScale);
     float current_scale = pixmapItem.scale();
     if(!pixmapItem.isUnderMouse() || current_scale == new_scale) return;
     
@@ -1255,23 +1254,9 @@ void ImageViewerV2::doZoomInCenterCursor(float new_scale) {
 
 
 void ImageViewerV2::doZoomIn(bool atCursor, bool pullCenter) {
-    float newScale = currentScale() * (1.0f + zoomStep);
-    if(useFixedZoomLevels && zoomLevels.count()) {
-        if(currentScale() < zoomLevels.first()) {
-            newScale = qMin(currentScale() * (1.0f + zoomStep), zoomLevels.first());
-        } else if(currentScale() >= zoomLevels.last()) {
-            newScale = currentScale() * (1.0f + zoomStep);
-        } else {
-            for(int i = 0; i < zoomLevels.count(); i++) {
-                float level = zoomLevels.at(i);
-                if(currentScale() < level) {
-                    newScale = level;
-                    break;
-                }
-            }
-        }
-    }
-    
+    float newScale = nextScale(true);
+    if(currentScale() == newScale)
+        return;
     
     // if the cursor isn't over the picture, fallback to other zoom
     if(pullCenter && pixmapItem.isUnderMouse()) {
@@ -1305,22 +1290,9 @@ void ImageViewerV2::zoomOutCursor() {
 }
 
 void ImageViewerV2::doZoomOut(bool atCursor) {
-    float newScale = currentScale() * (1.0f - zoomStep);
-    if(useFixedZoomLevels && zoomLevels.count()) {
-        if(currentScale() > zoomLevels.last()) {
-            newScale = qMax(zoomLevels.last(), currentScale() * (1.0f - zoomStep));
-        } else if(currentScale() <= zoomLevels.first()) {
-            newScale = currentScale() * (1.0f - zoomStep);
-        } else {
-            for(int i = zoomLevels.count() - 1; i >= 0; i--) {
-                float level = zoomLevels.at(i);
-                if(currentScale() > level) {
-                    newScale = level;
-                    break;
-                }
-            }
-        }
-    }
+    float newScale = nextScale(false);
+    if(currentScale() == newScale)
+        return;
     
     if(atCursor && underMouse())
         setZoomAnchor(mapFromGlobal(cursor().pos()));
@@ -1335,6 +1307,49 @@ void ImageViewerV2::doZoomOut(bool atCursor) {
         imageFitMode = FIT_WINDOW;
     else if(pixmapItem.scale() == fitWindowStretchScale)
         imageFitMode = FIT_WINDOW_STRETCH;
+}
+
+float ImageViewerV2::nextScale(bool zoom_in_or_out) {
+    float current_scale = pixmapItem.scale();
+    
+    float default_scale = current_scale * (zoom_in_or_out ? 1.0f+zoomStep : 1.0f-zoomStep);
+    
+    default_scale = qBound(minScale, default_scale, maxScale);
+    
+    if(!useFixedZoomLevels || !zoomLevels.count()) {
+        return default_scale;
+    }
+    
+    if(zoom_in_or_out ? zoomLevels.last() <= current_scale : current_scale <= zoomLevels.first()) {
+        return default_scale;
+    }
+    
+    if(zoom_in_or_out ? current_scale < zoomLevels.first() : zoomLevels.last() < current_scale) {
+        return zoom_in_or_out ?
+            qMin(default_scale, zoomLevels.first()) : qMax(default_scale, zoomLevels.last());
+    }
+    
+    // At this point we know that:
+    // zoom_in_or_out ? zoomLevels.first() <= current_scale < zoomLevels.last() : zoomLevels.first() < current_scale <= zoomLevels.last()
+    
+    if(zoom_in_or_out) {
+        for(int i = 0; i < zoomLevels.count(); i++) {
+            float scale = zoomLevels.at(i);
+            if(current_scale < scale)
+                return scale;
+            
+        }
+    } else {
+        for(int i = zoomLevels.count() - 1; i >= 0; i--) {
+            float scale = zoomLevels.at(i);
+            if(scale < current_scale)
+                return scale;
+            
+        }
+    }
+    
+    qDebug() << "error: unreachable code reached.\n";
+    return 1;
 }
 
 void ImageViewerV2::toggleLockZoom() {

--- a/qimgv/gui/viewers/imageviewerv2.h
+++ b/qimgv/gui/viewers/imageviewerv2.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QScreen>
 #include <QGraphicsView>
 #include <QGraphicsScene>
 #include <QGraphicsPixmapItem>
@@ -182,6 +183,7 @@ private:
     void scroll(int dx, int dy, bool animated);
     void doZoomInCenterCursor(float newScale);
     QPointF zoomBoxCenterCursor(float zoom_factor);
+    void updateSceneRect(bool called_by_resize_event = false);
 
     void mousePanWrapping(QMouseEvent *event);
     void mousePan(QMouseEvent *event);
@@ -211,4 +213,6 @@ private:
     void lockZoom();
     void doZoomIn(bool atCursor, bool pullCenter);
     void doZoomOut(bool atCursor);
+    
+    QSize screenDimensions;
 };

--- a/qimgv/gui/viewers/imageviewerv2.h
+++ b/qimgv/gui/viewers/imageviewerv2.h
@@ -25,10 +25,17 @@ enum MouseInteractionState {
     MOUSE_WHEEL_ZOOM
 };
 
-enum ViewLockMode {
-    LOCK_NONE,
-    LOCK_ZOOM,
-    LOCK_ALL
+enum ViewPreservationMode {
+    PRESERVE_NONE,
+    PRESERVE_ZOOM,
+    PRESERVE_VIEW,
+    PRESERVE_CURRENT_VIEW
+};
+
+enum ZoomPreservationMode {
+    PRESERVE_IMG_SCENE_WIDTH,
+    PRESERVE_IMG_SCENE_HEIGHT,
+    PRESERVE_IMG_PIXEL_DENSITY
 };
 
 class ImageViewerV2 : public QGraphicsView
@@ -104,8 +111,10 @@ public slots:
     void onFullscreenModeChanged(bool mode);
     void toggleLockZoom();
     bool lockZoomEnabled();
-    void toggleLockView();
-    bool lockViewEnabled();
+    void togglePreserveView();
+    void togglePreserveCurrentView();
+    bool preserveViewEnabled();
+    bool preserveCurrentViewEnabled();
 
 protected:
     virtual void mousePressEvent(QMouseEvent *event);
@@ -156,13 +165,15 @@ private:
 
     bool dragsEnabled = true;
     bool wayland = false;
+    ZoomPreservationMode zoomPreservationMode = PRESERVE_IMG_SCENE_WIDTH;
 
     float zoomStep = 0.1, dpr;
-    float minScale, maxScale, fitWindowScale, fitWindowStretchScale, expandLimit, lockedScale;
+    float minScale, maxScale, fitWindowScale, fitWindowStretchScale, expandLimit, savedZoomFactor_;
     QPointF zoomCursorPosition = QPointF(-1.0, 0.0);
     
+    qreal savedZoomFactor();
     QPointF savedViewportPos;
-    ViewLockMode mViewLock;
+    ViewPreservationMode viewPreservationMode = PRESERVE_NONE;
 
     QPair<QPointF, QPoint> zoomAnchor; // [pixmap coords, viewport coords]
     
@@ -211,7 +222,7 @@ private:
     void fitFree(float scale);
     void applySavedViewportPos();
     void saveViewportPos();
-    void lockZoom();
+    void saveZoomFactor();
     void doZoomIn(bool atCursor, bool pullCenter);
     void doZoomOut(bool atCursor);
     

--- a/qimgv/gui/viewers/imageviewerv2.h
+++ b/qimgv/gui/viewers/imageviewerv2.h
@@ -78,6 +78,7 @@ public slots:
     virtual void zoomOut();
     virtual void zoomInCursor();
     virtual void zoomOutCursor();
+    virtual void zoomInCenterCursor();
     virtual void readSettings();
     virtual void scrollUp();
     virtual void scrollDown();
@@ -157,6 +158,8 @@ private:
 
     float zoomStep = 0.1, dpr;
     float minScale, maxScale, fitWindowScale, fitWindowStretchScale, expandLimit, lockedScale;
+    QPointF zoomCursorPosition = QPointF(-1.0, 0.0);
+    
     QPointF savedViewportPos;
     ViewLockMode mViewLock;
 
@@ -177,6 +180,8 @@ private:
     void fitWindowStretch();
 
     void scroll(int dx, int dy, bool animated);
+    void doZoomInCenterCursor(float newScale);
+    QPointF zoomBoxCenterCursor(float zoom_factor);
 
     void mousePanWrapping(QMouseEvent *event);
     void mousePan(QMouseEvent *event);
@@ -204,6 +209,6 @@ private:
     void applySavedViewportPos();
     void saveViewportPos();
     void lockZoom();
-    void doZoomIn(bool atCursor);
+    void doZoomIn(bool atCursor, bool pullCenter);
     void doZoomOut(bool atCursor);
 };

--- a/qimgv/gui/viewers/imageviewerv2.h
+++ b/qimgv/gui/viewers/imageviewerv2.h
@@ -27,7 +27,6 @@ enum MouseInteractionState {
 
 enum ViewPreservationMode {
     PRESERVE_NONE,
-    PRESERVE_ZOOM,
     PRESERVE_VIEW,
     PRESERVE_CURRENT_VIEW
 };
@@ -109,8 +108,6 @@ public slots:
 
     bool showAnimationFrame(int frame);
     void onFullscreenModeChanged(bool mode);
-    void toggleLockZoom();
-    bool lockZoomEnabled();
     void togglePreserveView();
     void togglePreserveCurrentView();
     bool preserveViewEnabled();

--- a/qimgv/gui/viewers/imageviewerv2.h
+++ b/qimgv/gui/viewers/imageviewerv2.h
@@ -165,6 +165,8 @@ private:
     ViewLockMode mViewLock;
 
     QPair<QPointF, QPoint> zoomAnchor; // [pixmap coords, viewport coords]
+    
+    float nextScale(bool zoom_in_or_out);
 
     QElapsedTimer lastTouchpadScroll;
 

--- a/qimgv/gui/viewers/imageviewerv2.h
+++ b/qimgv/gui/viewers/imageviewerv2.h
@@ -136,7 +136,7 @@ private:
     QGraphicsPixmapItem pixmapItem, pixmapItemScaled;
     QTimer *animationTimer, *scaleTimer;
     QScrollBar *hs, *vs;
-    QPoint mouseMoveStartPos, mousePressPos, drawPos;
+    QPoint mouseMoveStartPos, mousePressPos;
     bool transparencyGrid, expandImage,    smoothAnimatedImages,
          smoothUpscaling,  forceFastScale, keepFitMode,
          loopPlayback,     mIsFullscreen,  scrollBarWorkaround,
@@ -185,7 +185,6 @@ private:
     QPointF zoomBoxCenterCursor(float zoom_factor);
     void updateSceneRect(bool called_by_resize_event = false);
 
-    void mousePanWrapping(QMouseEvent *event);
     void mousePan(QMouseEvent *event);
     void mouseMoveZoom(QMouseEvent *event);
     void reset();

--- a/qimgv/gui/viewers/viewerwidget.cpp
+++ b/qimgv/gui/viewers/viewerwidget.cpp
@@ -171,7 +171,8 @@ void ViewerWidget::setInteractionEnabled(bool mode) {
     mInteractionEnabled = mode;
     if(mInteractionEnabled) {
         connect(this, &ViewerWidget::toggleLockZoom, imageViewer.get(), &ImageViewerV2::toggleLockZoom);
-        connect(this, &ViewerWidget::toggleLockView, imageViewer.get(), &ImageViewerV2::toggleLockView);
+        connect(this, &ViewerWidget::togglePreserveView, imageViewer.get(), &ImageViewerV2::togglePreserveView);
+        connect(this, &ViewerWidget::togglePreserveCurrentView, imageViewer.get(), &ImageViewerV2::togglePreserveCurrentView);
         connect(this, &ViewerWidget::zoomIn,         imageViewer.get(), &ImageViewerV2::zoomIn);
         connect(this, &ViewerWidget::zoomOut,        imageViewer.get(), &ImageViewerV2::zoomOut);
         connect(this, &ViewerWidget::zoomInCursor,   imageViewer.get(), &ImageViewerV2::zoomInCursor);
@@ -363,8 +364,12 @@ bool ViewerWidget::lockZoomEnabled() {
     return imageViewer->lockZoomEnabled();
 }
 
-bool ViewerWidget::lockViewEnabled() {
-    return imageViewer->lockViewEnabled();
+bool ViewerWidget::preserveViewEnabled() {
+    return imageViewer->preserveViewEnabled();
+}
+
+bool ViewerWidget::preserveCurrentViewEnabled() {
+    return imageViewer->preserveCurrentViewEnabled();
 }
 
 ScalingFilter ViewerWidget::scalingFilter() {

--- a/qimgv/gui/viewers/viewerwidget.cpp
+++ b/qimgv/gui/viewers/viewerwidget.cpp
@@ -176,6 +176,7 @@ void ViewerWidget::setInteractionEnabled(bool mode) {
         connect(this, &ViewerWidget::zoomOut,        imageViewer.get(), &ImageViewerV2::zoomOut);
         connect(this, &ViewerWidget::zoomInCursor,   imageViewer.get(), &ImageViewerV2::zoomInCursor);
         connect(this, &ViewerWidget::zoomOutCursor,  imageViewer.get(), &ImageViewerV2::zoomOutCursor);
+        connect(this, &ViewerWidget::zoomInCenterCursor,  imageViewer.get(), &ImageViewerV2::zoomInCenterCursor);
         connect(this, &ViewerWidget::scrollUp,       imageViewer.get(), &ImageViewerV2::scrollUp);
         connect(this, &ViewerWidget::scrollDown,     imageViewer.get(), &ImageViewerV2::scrollDown);
         connect(this, &ViewerWidget::scrollLeft,     imageViewer.get(), &ImageViewerV2::scrollLeft);
@@ -191,6 +192,7 @@ void ViewerWidget::setInteractionEnabled(bool mode) {
         disconnect(this, &ViewerWidget::zoomOut,       imageViewer.get(), &ImageViewerV2::zoomOut);
         disconnect(this, &ViewerWidget::zoomInCursor,  imageViewer.get(), &ImageViewerV2::zoomInCursor);
         disconnect(this, &ViewerWidget::zoomOutCursor, imageViewer.get(), &ImageViewerV2::zoomOutCursor);
+        disconnect(this, &ViewerWidget::zoomInCenterCursor, imageViewer.get(), &ImageViewerV2::zoomInCenterCursor);
         disconnect(this, &ViewerWidget::scrollUp,      imageViewer.get(), &ImageViewerV2::scrollUp);
         disconnect(this, &ViewerWidget::scrollDown,    imageViewer.get(), &ImageViewerV2::scrollDown);
         disconnect(this, &ViewerWidget::scrollLeft,    imageViewer.get(), &ImageViewerV2::scrollLeft);

--- a/qimgv/gui/viewers/viewerwidget.cpp
+++ b/qimgv/gui/viewers/viewerwidget.cpp
@@ -170,7 +170,6 @@ void ViewerWidget::setInteractionEnabled(bool mode) {
         return;
     mInteractionEnabled = mode;
     if(mInteractionEnabled) {
-        connect(this, &ViewerWidget::toggleLockZoom, imageViewer.get(), &ImageViewerV2::toggleLockZoom);
         connect(this, &ViewerWidget::togglePreserveView, imageViewer.get(), &ImageViewerV2::togglePreserveView);
         connect(this, &ViewerWidget::togglePreserveCurrentView, imageViewer.get(), &ImageViewerV2::togglePreserveCurrentView);
         connect(this, &ViewerWidget::zoomIn,         imageViewer.get(), &ImageViewerV2::zoomIn);
@@ -358,10 +357,6 @@ bool ViewerWidget::isDisplaying() {
         return true;
     else
         return false;
-}
-
-bool ViewerWidget::lockZoomEnabled() {
-    return imageViewer->lockZoomEnabled();
 }
 
 bool ViewerWidget::preserveViewEnabled() {

--- a/qimgv/gui/viewers/viewerwidget.h
+++ b/qimgv/gui/viewers/viewerwidget.h
@@ -32,7 +32,8 @@ public:
     void onScalingFinished(std::unique_ptr<QPixmap> scaled);
     bool isDisplaying();
     bool lockZoomEnabled();
-    bool lockViewEnabled();
+    bool preserveCurrentViewEnabled();
+    bool preserveViewEnabled();
     ScalingFilter scalingFilter();
 
 private:
@@ -87,7 +88,8 @@ signals:
     void setScalingFilter(ScalingFilter filter);
     void playbackFinished();
     void toggleLockZoom();
-    void toggleLockView();
+    void togglePreserveView();
+    void togglePreserveCurrentView();
     void showScriptSettings();
 
 public slots:

--- a/qimgv/gui/viewers/viewerwidget.h
+++ b/qimgv/gui/viewers/viewerwidget.h
@@ -71,6 +71,7 @@ signals:
     void zoomOut();
     void zoomInCursor();
     void zoomOutCursor();
+    void zoomInCenterCursor();
     void scrollUp();
     void scrollDown();
     void scrollLeft();

--- a/qimgv/gui/viewers/viewerwidget.h
+++ b/qimgv/gui/viewers/viewerwidget.h
@@ -31,7 +31,6 @@ public:
     bool showAnimation(std::shared_ptr<QMovie> movie);
     void onScalingFinished(std::unique_ptr<QPixmap> scaled);
     bool isDisplaying();
-    bool lockZoomEnabled();
     bool preserveCurrentViewEnabled();
     bool preserveViewEnabled();
     ScalingFilter scalingFilter();
@@ -87,7 +86,6 @@ signals:
     void setFilterBilinear();
     void setScalingFilter(ScalingFilter filter);
     void playbackFinished();
-    void toggleLockZoom();
     void togglePreserveView();
     void togglePreserveCurrentView();
     void showScriptSettings();

--- a/qimgv/res/translations/de_DE.ts
+++ b/qimgv/res/translations/de_DE.ts
@@ -5,11 +5,13 @@
     <name>ChangelogWindow</name>
     <message>
         <location filename="../../gui/overlays/changelogwindow.ui" line="154"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_changelogwindow.h" line="137"/>
         <source>Close, never show changelogs</source>
         <translation>Schließen, zeige keine Änderungshistorie</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/changelogwindow.ui" line="170"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_changelogwindow.h" line="138"/>
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
@@ -17,62 +19,63 @@
 <context>
     <name>ContextMenu</name>
     <message>
-        <location filename="../../gui/contextmenu.ui" line="229"/>
+        <location filename="../../gui/contextmenu.ui" line="236"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_contextmenu.h" line="449"/>
         <source>Edit</source>
         <translation>Bearbeiten</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="55"/>
+        <location filename="../../gui/contextmenu.cpp" line="58"/>
         <source>Print</source>
         <translation>Drucken</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="59"/>
+        <location filename="../../gui/contextmenu.cpp" line="62"/>
         <source>Quick copy</source>
         <translation>Schnell kopieren</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="63"/>
+        <location filename="../../gui/contextmenu.cpp" line="66"/>
         <source>Quick move</source>
         <translation>Schnell verschieben</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="67"/>
+        <location filename="../../gui/contextmenu.cpp" line="70"/>
         <source>Move to trash</source>
         <translation>In den Papierkorb verschieben</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="72"/>
+        <location filename="../../gui/contextmenu.cpp" line="75"/>
         <source>Open</source>
         <translation>Öffnen</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="77"/>
+        <location filename="../../gui/contextmenu.cpp" line="80"/>
         <source>Folder View</source>
         <translation>Ordneransicht</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="82"/>
+        <location filename="../../gui/contextmenu.cpp" line="85"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="85"/>
+        <location filename="../../gui/contextmenu.cpp" line="88"/>
         <source>Open with...</source>
         <translation>Öffnen mit...</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="91"/>
+        <location filename="../../gui/contextmenu.cpp" line="94"/>
         <source>Show in folder</source>
         <translation>Zeige im Ordner</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="99"/>
+        <location filename="../../gui/contextmenu.cpp" line="102"/>
         <source>Back</source>
         <translation>Zurück</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="102"/>
+        <location filename="../../gui/contextmenu.cpp" line="105"/>
         <source>Configure menu</source>
         <translation>Menü anpassen</translation>
     </message>
@@ -94,228 +97,228 @@
 <context>
     <name>Core</name>
     <message>
-        <location filename="../../core.cpp" line="255"/>
+        <location filename="../../core.cpp" line="258"/>
         <source>Updated: </source>
         <translation>Aktualisiert: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="261"/>
+        <location filename="../../core.cpp" line="264"/>
         <source>Welcome to </source>
         <translation>Willkommen zu </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="261"/>
+        <location filename="../../core.cpp" line="264"/>
         <source> version </source>
         <translation> Version </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="268"/>
+        <location filename="../../core.cpp" line="271"/>
         <source>Shuffle mode: OFF</source>
         <translation>Zufallswiedergabe: AUS</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="271"/>
+        <location filename="../../core.cpp" line="274"/>
         <source>Shuffle mode: ON</source>
         <translation>Zufallswiedergabe: AN</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="280"/>
+        <location filename="../../core.cpp" line="283"/>
         <source>Slideshow: OFF</source>
         <translation>Diashiow: AUS</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="284"/>
+        <location filename="../../core.cpp" line="287"/>
         <source>Slideshow: ON</source>
         <translation>Diashow: EIN</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="355"/>
+        <location filename="../../core.cpp" line="358"/>
         <source>Delete </source>
         <translation>Lösche </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="355"/>
+        <location filename="../../core.cpp" line="358"/>
         <source> items permanently?</source>
         <translation> Elemente permanent?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="357"/>
+        <location filename="../../core.cpp" line="360"/>
         <source>Delete item permanently?</source>
         <translation>Element permanent löschen?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="358"/>
+        <location filename="../../core.cpp" line="361"/>
         <source>Delete permanently</source>
         <translation>Permanent löschen</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="374"/>
+        <location filename="../../core.cpp" line="377"/>
         <source>File removed</source>
         <translation>Datei entfernt</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="378"/>
+        <location filename="../../core.cpp" line="381"/>
         <source>Removed: </source>
         <translation>Entfernt: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="378"/>
-        <location filename="../../core.cpp" line="408"/>
+        <location filename="../../core.cpp" line="381"/>
+        <location filename="../../core.cpp" line="411"/>
         <source> files</source>
         <translation> Dateien</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="389"/>
+        <location filename="../../core.cpp" line="392"/>
         <source>Move </source>
         <translation>Verschiebe </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="389"/>
+        <location filename="../../core.cpp" line="392"/>
         <source> items to trash?</source>
         <translation> Elemente in den Papierkorb?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="391"/>
+        <location filename="../../core.cpp" line="394"/>
         <source>Move item to trash?</source>
         <translation>Element in den Papierkorb verschieben?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="392"/>
+        <location filename="../../core.cpp" line="395"/>
         <source>Move to trash</source>
         <translation>In den Papierkorb verschieben</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="404"/>
+        <location filename="../../core.cpp" line="407"/>
         <source>Moved to trash</source>
         <translation>In den Papierkorb verschoben</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="408"/>
+        <location filename="../../core.cpp" line="411"/>
         <source>Moved to trash: </source>
         <translation>In den Papierkorb verschoben: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="463"/>
+        <location filename="../../core.cpp" line="466"/>
         <source>File copied</source>
         <translation>Datei kopiert</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="470"/>
+        <location filename="../../core.cpp" line="473"/>
         <source>Path copied</source>
         <translation>Pfad kopiert</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="644"/>
-        <location filename="../../core.cpp" line="918"/>
-        <location filename="../../core.cpp" line="939"/>
+        <location filename="../../core.cpp" line="647"/>
+        <location filename="../../core.cpp" line="928"/>
+        <location filename="../../core.cpp" line="949"/>
         <source>File exists</source>
         <translation>Datei existiert</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="644"/>
+        <location filename="../../core.cpp" line="647"/>
         <source>Overwrite file?</source>
         <translation>Datei überschreiben?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="812"/>
-        <location filename="../../core.cpp" line="880"/>
+        <location filename="../../core.cpp" line="822"/>
+        <location filename="../../core.cpp" line="890"/>
         <source>Could not create directory </source>
         <translation>Ordner konnte nicht angelegt werden </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="916"/>
+        <location filename="../../core.cpp" line="926"/>
         <source>File moved.</source>
         <translation>Datei verschoben.</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="918"/>
-        <location filename="../../core.cpp" line="939"/>
+        <location filename="../../core.cpp" line="928"/>
+        <location filename="../../core.cpp" line="949"/>
         <source>Destination file exists. Overwrite?</source>
         <translation>Zieldatei existiert. Überschreiben?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="937"/>
+        <location filename="../../core.cpp" line="947"/>
         <source>File copied.</source>
         <translation>Datei kopiert.</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="984"/>
+        <location filename="../../core.cpp" line="994"/>
         <source>Perform action &quot;</source>
         <translation>Aktion ausführen &quot;</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="984"/>
+        <location filename="../../core.cpp" line="994"/>
         <source>Changes will be saved immediately.</source>
         <translation>Änderungen werden sofort gespeichert.</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1002"/>
+        <location filename="../../core.cpp" line="1012"/>
         <source>Flip horizontal</source>
         <translation>Spiegel horizontal</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1006"/>
+        <location filename="../../core.cpp" line="1016"/>
         <source>Flip vertical</source>
         <translation>Spiegel vertikal</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1010"/>
+        <location filename="../../core.cpp" line="1020"/>
         <source>Rotate</source>
         <translation>Drehe</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1014"/>
+        <location filename="../../core.cpp" line="1024"/>
         <source>Resize</source>
         <translation>Größe ändern</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1020"/>
-        <location filename="../../core.cpp" line="1026"/>
+        <location filename="../../core.cpp" line="1030"/>
+        <location filename="../../core.cpp" line="1036"/>
         <source>Crop</source>
         <translation>Zuschneiden</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1058"/>
+        <location filename="../../core.cpp" line="1068"/>
         <source>File saved</source>
         <translation>Datei gespeichert</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1061"/>
+        <location filename="../../core.cpp" line="1071"/>
         <source>Could not save file</source>
         <translation>Datei konnte nicht gespeichert werden</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1171"/>
+        <location filename="../../core.cpp" line="1181"/>
         <source>Could not open image</source>
         <translation>Bild konnte nicht geöffnet werden</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1175"/>
+        <location filename="../../core.cpp" line="1185"/>
         <source>Can only print static images</source>
         <translation>Nur unbewegte Bilder können gedruckt werden</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1226"/>
+        <location filename="../../core.cpp" line="1236"/>
         <source>Could not open path: </source>
         <translation>Pfad konnte nicht geöffnet werden: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1260"/>
+        <location filename="../../core.cpp" line="1270"/>
         <source>Could not load folder: </source>
         <translation>Ordner konnte nicht geladen werden: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1413"/>
+        <location filename="../../core.cpp" line="1423"/>
         <source>End of directory.</source>
         <translation>Ende des Ordners.</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1452"/>
+        <location filename="../../core.cpp" line="1462"/>
         <source>Load failed: </source>
         <translation>Laden fehlgeschlagen: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1496"/>
+        <location filename="../../core.cpp" line="1506"/>
         <source>Error: could not load image.</source>
         <translation>Fehler: Das Bild konnte nicht geladen werden.</translation>
     </message>
@@ -324,77 +327,92 @@
     <name>CropPanel</name>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="107"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="370"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="125"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="371"/>
         <source>Width</source>
         <translation>Breite</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="161"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="372"/>
         <source>Height</source>
         <translation>Höhe</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="322"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="374"/>
         <source>Aspect Ratio</source>
         <translation>Seitenverhältnis</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="336"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="375"/>
         <source>Free</source>
         <translation>Frei</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="341"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="376"/>
         <source>Custom</source>
         <translation>Benutzerdefiniert</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="346"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="377"/>
         <source>Current Image</source>
         <translation>Aktuelles Bild</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="351"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="378"/>
         <source>This Screen</source>
         <translation>Dieser Bildschirm</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="356"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="379"/>
         <source>1:1</source>
         <translation>1:1</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="361"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="380"/>
         <source>4:3</source>
         <translation>4:3</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="366"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="381"/>
         <source>16:9</source>
         <translation>16:9</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="371"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="382"/>
         <source>16:10</source>
         <translation>16:10</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="499"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="385"/>
         <source>Crop</source>
         <translation>Zuschneiden</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="512"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="386"/>
         <source>Crop &amp;&amp; Save</source>
         <translatorcomment>given how large the German words are, saving two chars by not using &quot;und&quot; seemed weird</translatorcomment>
         <translation>Zuschneiden und Speichern</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="527"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="387"/>
         <source>Cancel</source>
         <translation>Abbruch</translation>
     </message>
@@ -403,11 +421,13 @@
     <name>FVOptionsPopup</name>
     <message>
         <location filename="../../gui/folderview/fvoptionspopup.ui" line="32"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_fvoptionspopup.h" line="86"/>
         <source>Form</source>
         <translation>Formular</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/fvoptionspopup.ui" line="53"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_fvoptionspopup.h" line="87"/>
         <source>View options</source>
         <translation>Zeige Optionen</translation>
     </message>
@@ -416,57 +436,68 @@
     <name>FileReplaceDialog</name>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="14"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="130"/>
         <source>Dialog</source>
         <translation>Dialog</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="20"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="131"/>
         <source>title</source>
         <translation>Titel</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="33"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="132"/>
         <source>Source:</source>
         <translation>Quelle:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="40"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="133"/>
         <source>src</source>
         <translatorcomment>idk if this even gets used?</translatorcomment>
         <translation>src</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="50"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="134"/>
         <source>&gt;&gt;&gt;</source>
         <translation>&gt;&gt;&gt;</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="63"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="135"/>
         <source>Destination:</source>
         <translation>Ziel:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="70"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="136"/>
         <source>dst</source>
         <translation>dst</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="111"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="137"/>
         <source>Apply to all</source>
         <translation>Auf alle anwenden</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="118"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="138"/>
         <source>Yes</source>
         <translation>Ja</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="125"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="139"/>
         <source>No</source>
         <translation>Nein</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="132"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="140"/>
         <source>Cancel</source>
         <translation>Abbruch</translation>
     </message>
@@ -475,79 +506,95 @@
     <name>FolderView</name>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="17"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="410"/>
         <source>Form</source>
         <translation>Formular</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="145"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="411"/>
         <source>[path]</source>
         <translatorcomment>why are there brackets?</translatorcomment>
         <translation>[Pfad]</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="195"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="413"/>
         <source>FolderViewSlider</source>
         <translatorcomment>I feel like this isn&apos; supposed to be translated or it could break something?</translatorcomment>
         <translation>FolderViewSlider</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="242"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="416"/>
         <source>CheckableButton</source>
         <translation>CheckableButton</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="274"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="426"/>
         <source>PanelComboBox</source>
         <translation>PanelComboBox</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="281"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="418"/>
         <source>A - Z</source>
         <translation>A - Z</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="286"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="419"/>
         <source>Z - A</source>
         <translation>Z - A</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="291"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="420"/>
         <source>Size</source>
         <translation>Größe</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="296"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="421"/>
         <source>Size (desc)</source>
         <translation>Größe (abst.)</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="301"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="422"/>
         <source>Oldest</source>
         <translation>Älteste</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="306"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="423"/>
         <source>Newest</source>
         <translation>Neuste</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="348"/>
         <location filename="../../gui/folderview/folderview.ui" line="373"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="429"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="432"/>
         <source>PanelButton</source>
         <translation>PanelButton</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="414"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="435"/>
         <source>PanelButtonRE</source>
         <translation>PanelButtonRE</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="476"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="438"/>
         <source>PlacesPanel</source>
         <translation>PlacesPanel</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="532"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="440"/>
         <source>BOOKMARKS</source>
         <translatorcomment>Why the caps?</translatorcomment>
         <translation>LESEZEICHEN</translation>
@@ -556,11 +603,15 @@
         <location filename="../../gui/folderview/folderview.ui" line="551"/>
         <location filename="../../gui/folderview/folderview.ui" line="638"/>
         <location filename="../../gui/folderview/folderview.ui" line="657"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="442"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="446"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="449"/>
         <source>PlacesPanelButton</source>
         <translation>PlacesPanelButton</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="611"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="444"/>
         <source>FILESYSTEM</source>
         <translation>DATEISYSTEM</translation>
     </message>
@@ -569,11 +620,13 @@
     <name>ImageInfoOverlay</name>
     <message>
         <location filename="../../gui/overlays/imageinfooverlay.ui" line="65"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_imageinfooverlay.h" line="111"/>
         <source>OverlayHeaderWidget</source>
         <translation>OverlayHeaderWidget</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/imageinfooverlay.ui" line="99"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_imageinfooverlay.h" line="113"/>
         <source>EXIF Tags</source>
         <translation>EXIF Metadaten</translation>
     </message>
@@ -589,35 +642,35 @@
 <context>
     <name>MW</name>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="565"/>
+        <location filename="../../gui/mainwindow.cpp" line="581"/>
         <source>Save File as...</source>
         <translation>Speichere Datei als...</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="800"/>
+        <location filename="../../gui/mainwindow.cpp" line="816"/>
         <source>Folder view</source>
         <translation>Ordneransicht</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="801"/>
-        <location filename="../../gui/mainwindow.cpp" line="802"/>
-        <location filename="../../gui/mainwindow.cpp" line="805"/>
-        <location filename="../../gui/mainwindow.cpp" line="806"/>
+        <location filename="../../gui/mainwindow.cpp" line="817"/>
+        <location filename="../../gui/mainwindow.cpp" line="818"/>
+        <location filename="../../gui/mainwindow.cpp" line="821"/>
+        <location filename="../../gui/mainwindow.cpp" line="822"/>
         <source>No file opened.</source>
         <translation>Keine Datei geöffnet.</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="867"/>
+        <location filename="../../gui/mainwindow.cpp" line="883"/>
         <source>Fit Window</source>
         <translation>An Fenster anpassen</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="871"/>
+        <location filename="../../gui/mainwindow.cpp" line="887"/>
         <source>Fit Width</source>
         <translation>An Breite anpassen</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="875"/>
+        <location filename="../../gui/mainwindow.cpp" line="891"/>
         <source>Fit 1:1</source>
         <translation>Auf 1:1 skalieren</translation>
     </message>
@@ -626,71 +679,85 @@
     <name>PrintDialog</name>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="20"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="304"/>
         <source>Print image</source>
         <translation>Bild drucken</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="126"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="306"/>
         <source>Preview</source>
         <translation>Vorschau</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="179"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="307"/>
         <source>Printer:</source>
         <translation>Drucker:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="189"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="308"/>
         <source>&lt;No printers found&gt;</source>
         <translation>&lt;Kein Drucker gefunden&gt;</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="271"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="309"/>
         <source>Page orientation:</source>
         <translation>Seitenausrichtung:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="297"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="310"/>
         <source>Portrait</source>
         <translation>Portrait</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="307"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="311"/>
         <source>Landscape</source>
         <translation>Landschaft</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="348"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="312"/>
         <source>Color mode:</source>
         <translation>Farbmodus:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="374"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="313"/>
         <source>Grayscale</source>
         <translation>Graustufe</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="384"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="314"/>
         <source>Color</source>
         <translation>Farbe</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="409"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="315"/>
         <source>Fit to page</source>
         <translation>An Seite anpassen</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="434"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="316"/>
         <source>Export PDF</source>
         <translation>PDF exportieren</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="454"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="317"/>
         <source>Print</source>
         <translation>Drucken</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="464"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="318"/>
         <source>Cancel</source>
         <translation>Abbruch</translation>
     </message>
@@ -830,11 +897,14 @@
     <message>
         <location filename="../../gui/overlays/renameoverlay.ui" line="171"/>
         <location filename="../../gui/overlays/renameoverlay.ui" line="260"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_renameoverlay.h" line="213"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_renameoverlay.h" line="214"/>
         <source>Rename</source>
         <translation>Umbenennen</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/renameoverlay.ui" line="273"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_renameoverlay.h" line="215"/>
         <source>Cancel</source>
         <translation>Abbruch</translation>
     </message>
@@ -843,152 +913,182 @@
     <name>ResizeDialog</name>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="32"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="358"/>
         <source>Resize</source>
         <translation>Größe ändern</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="63"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="359"/>
         <source>By Percent:</source>
         <translation>In Prozent:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="79"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="360"/>
         <source>By Absolute Size:</source>
         <translation>In Absoluter Größe:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="98"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="361"/>
         <source>Percent:</source>
         <translation>Prozent:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="119"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="362"/>
         <source>Width:</source>
         <translation>Breite:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="205"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="363"/>
         <source>Height:</source>
         <translation>Höhe:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="275"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="364"/>
         <source>Keep aspect ratio</source>
         <translation>Seitenverhältnis beibehalten</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="304"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="365"/>
         <source>Filter:</source>
         <translation>Filter:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="330"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="366"/>
         <source>Nearest</source>
         <translatorcomment>Would be to confusing to translate</translatorcomment>
         <translation>Nearest</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="335"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="367"/>
         <source>Bilinear</source>
         <translation>Bilinear</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="340"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="368"/>
         <source>Bicubic</source>
         <translation>Bicubic</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="345"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="369"/>
         <source>Lanczos3</source>
         <translation>Lanczos3</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="358"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="371"/>
         <source>Common sizes:</source>
         <translation>Übliche Größen:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="392"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="372"/>
         <source>Select:</source>
         <translation>Auswählen:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="397"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="373"/>
         <source>1366 x 768</source>
         <translation>1366 x 768</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="402"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="374"/>
         <source>1440 x 900</source>
         <translation>1440 x 900</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="407"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="375"/>
         <source>1440 x 1050</source>
         <translation>1440 x 1050</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="412"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="376"/>
         <source>1600 x 1200</source>
         <translation>1600 x 1200</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="417"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="377"/>
         <source>1920 x 1080 (FullHD)</source>
         <translation>1920 x 1080 (FullHD)</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="422"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="378"/>
         <source>1920 x 1200 (FullHD)</source>
         <translation>1920 x 1200 (FullHD)</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="427"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="379"/>
         <source>2560 x 1080</source>
         <translation>2560 x 1080</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="432"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="380"/>
         <source>2560 x 1440</source>
         <translation>2560 x 1440</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="437"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="381"/>
         <source>2560 x 1600</source>
         <translation>2560 x 1600</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="442"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="382"/>
         <source>3840 x 1600 (UW 4K)</source>
         <translation>3840 x 1600 (UW 4K)</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="447"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="383"/>
         <source>3840 x 2160 (UHD-1)</source>
         <translation>3840 x 2160 (UHD-1)</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="470"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="385"/>
         <source>Fit to desktop</source>
         <translation>An Schreibtisch anpassen</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="489"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="386"/>
         <source>Fill desktop (expanding)</source>
         <translation>Schreibtisch füllen</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="508"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="387"/>
         <source>Reset</source>
         <translation>Zurücksetzen</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="575"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="388"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="594"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="389"/>
         <source>Cancel</source>
         <translation>Abbruch</translation>
     </message>
@@ -1040,21 +1140,25 @@
     <name>SaveConfirmOverlay</name>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="81"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="145"/>
         <source>Unsaved edits</source>
         <translation>Ungespeicherte Änderungen</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="127"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="146"/>
         <source>Save</source>
         <translation>Speichern</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="140"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="147"/>
         <source>Save as</source>
         <translation>Speichern als</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="169"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="148"/>
         <source>Discard</source>
         <translation>Verwerfen</translation>
     </message>
@@ -1063,31 +1167,37 @@
     <name>ScriptEditorDialog</name>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="48"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="208"/>
         <source>Command:</source>
         <translation>Befehl:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="84"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="209"/>
         <source>NOTE: make sure your .sh script has execute flag.</source>
         <translation>HINWEIS: Stelle sicher, dass dein Skript ausführbar ist.</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="91"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="210"/>
         <source>Name:</source>
         <translation>Name:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="148"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="212"/>
         <source>Wait to finish</source>
         <translation>Auf die Beendigung warten</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="218"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="214"/>
         <source>Create</source>
         <translation>Erstellen</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="225"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="215"/>
         <source>Cancel</source>
         <translation>Abbruch</translation>
     </message>
@@ -1132,753 +1242,934 @@
     <name>SettingsDialog</name>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="47"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2892"/>
         <source>Preferences</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="53"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2894"/>
         <source>SettingsDialog</source>
         <translation>EinstellungsDialog</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="339"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2900"/>
         <source>General</source>
         <translation>Allgemein</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="415"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2901"/>
         <source>Language:</source>
         <translation>Sprache:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="435"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2902"/>
         <source>Requires application restart</source>
         <translation>Benötigt Anwendungsneustart</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="473"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2903"/>
         <source>Open in fullscreen</source>
         <translation>Im Vollbild öffnen</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="480"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2904"/>
         <source>Start in folder view by default</source>
         <translation>Starte in der Ordneransicht</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="551"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2905"/>
         <source>User interface</source>
         <translation>Benutzeroberfläche</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="606"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2906"/>
         <source>Image info in window title</source>
         <translation>Bildinformationen im Fenstertitel</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="626"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2907"/>
         <source>Auto-hide cursor</source>
         <translation>Mauszeiger verstecken</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="633"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2909"/>
         <source>Turn this off if you are using a touchpad with libinput driver.</source>
         <translation>Schalten Sie dies aus, falls Sie ein TouchPad mit libinput Treiber benutzen.</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="636"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2911"/>
         <source>Enable smooth scrolling</source>
         <translation>Sanftes Scrollen aktivieren</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="643"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2912"/>
         <source>Fullscreen info bar</source>
         <translation>Vollbild Informationsleiste</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="656"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2913"/>
         <source>Status bar</source>
         <translation>Statusleiste</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="689"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2914"/>
         <source>Zoom indicator:</source>
         <translation>Zoom Indikator:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="699"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2915"/>
         <source>On</source>
         <translation>Ein</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="706"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2916"/>
         <source>Off</source>
         <translation>Aus</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="713"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2917"/>
         <source>Auto</source>
         <translation>Auto</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="753"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2918"/>
         <source>Automatic window resize</source>
         <translation>Automatische Fenstergrößenanpassung</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="763"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2919"/>
         <source>Match displayed content</source>
         <translation>An gezeigten Inhalten anpassen</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="799"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2920"/>
         <source>Screen area limit for auto resize:</source>
         <translation>Obergrenze der Bildschirmfläche bei autom. Anpassung:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="864"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2240"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2261"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2921"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2978"/>
         <source>xx</source>
         <translation>xx</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="962"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2925"/>
         <source>Thumbnail panel</source>
         <translation>Vorschaubildübersicht</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1018"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2926"/>
         <source>Crop previews</source>
         <translation>Zuschnittsvorschau</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1031"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2927"/>
         <source>Pinned</source>
         <translation>Angeheftet</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1050"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2928"/>
         <source>Disable in windowed mode</source>
         <translation>Deaktiviert im Fenstermodus</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1057"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2929"/>
         <source>Center selected image</source>
         <translation>Zentriere ausgewähltes Bild</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1109"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2930"/>
         <source>Extended</source>
         <translation>Erweitert</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1119"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2931"/>
         <source>Previews only</source>
         <translation>Nur Vorschaubilder</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1126"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2932"/>
         <source>Display style:</source>
         <translation>Anzeigestil:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1139"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2933"/>
         <source>Show filename and resolution</source>
         <translation>Zeige Dateiname und Auflösung</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1159"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2934"/>
         <source>Simple</source>
         <translation>Einfach</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1183"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2935"/>
         <source>Preview size:</source>
         <translation>Vorschaugröße:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1258"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2936"/>
         <source>Position:</source>
         <translation>Position:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1266"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2064"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2085"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2937"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2972"/>
         <source>Top</source>
         <translation>Oben</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1271"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2938"/>
         <source>Bottom</source>
         <translation>Unten</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1276"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2939"/>
         <source>Left</source>
         <translation>Links</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1281"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2940"/>
         <source>Right</source>
         <translation>Rechts</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1374"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2942"/>
         <source>Folder navigation</source>
         <translation>Ordnernavigation</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1400"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2943"/>
         <source>Stop</source>
         <translation>Anhalten</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1410"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2944"/>
         <source>Loop folder</source>
         <translation>Ordner wiederholen</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1417"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2945"/>
         <source>Go to the next folder</source>
         <translation>Zum nächsten Ordner wechseln</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1424"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2946"/>
         <source>After reaching the end:</source>
         <translation>Nach Erreichen des Endes:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1476"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2947"/>
         <source>Default sorting mode:</source>
         <translation>Standard Sortiermodus:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1493"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2948"/>
         <source>A - Z</source>
         <translation>A - Z</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1498"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2949"/>
         <source>Z - A</source>
         <translation>Z - A</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1503"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2950"/>
         <source>Size</source>
         <translation>Größe</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1508"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2951"/>
         <source>Size (desc)</source>
         <translation>Größe (abst.)</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1513"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2952"/>
         <source>Oldest</source>
         <translation>Älteste</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1518"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2953"/>
         <source>Newest</source>
         <translation>Neuste</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1541"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2955"/>
         <source>Apply sorting to folders</source>
         <translation>Sortierung auf Ordner anwenden</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1609"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1555"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2956"/>
+        <source>Show hidden files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1623"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2957"/>
         <source>Video playback</source>
         <translation>Videowiedergabe</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1651"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1665"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2958"/>
         <source>Play sounds</source>
         <translation>Tonwiedergabe</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1720"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1734"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2959"/>
         <source>Slideshow</source>
         <translation>Diashow</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1740"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1754"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2960"/>
         <source>Switch interval:</source>
         <translation>Umschaltintervall:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1771"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1785"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2961"/>
         <source>ms</source>
         <translation>ms</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1803"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1817"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2962"/>
         <source>Loop slideshow</source>
         <translation>Diashow in Schleife</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1900"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1914"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2963"/>
         <source>View</source>
         <translation>Ansicht</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1956"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1970"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2964"/>
         <source>Display options</source>
         <translation>Zeige Optionen</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1980"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1994"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2965"/>
         <source>Image fit:</source>
         <translation>Bildanpassung:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1987"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2001"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2966"/>
         <source>Fit in window</source>
         <translation>An Fenster anpassen</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1997"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2011"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2967"/>
         <source>Stretch to width</source>
         <translation>An Breite anpassen</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2004"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2018"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2968"/>
         <source>1:1</source>
         <translation>1:1</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="2025"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2969"/>
         <source>Fit in window (stretch)</source>
         <translation>An Fenster anpassen (strecken)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2026"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2047"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2970"/>
         <source>Keep fit mode when switching images</source>
         <translation>Anpassungsmodus beibehalten beim Bildwechsel</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2057"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2078"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2971"/>
         <source>Focus in 1:1 mode:</source>
         <translation>Fokus im 1:1-Modus:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2071"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2092"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2973"/>
         <source>Center</source>
         <translation>Mitte</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2078"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2099"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2974"/>
         <source>At cursor</source>
         <translation>Am Mauszeiger</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2103"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2124"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2975"/>
         <source>Part of image that&apos;s focused after switching to 1:1</source>
         <translation>Teil des Bildes im Fokus nach dem Wechsel zu 1:1</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2126"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2147"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2976"/>
         <source>Grid background on images with transparency</source>
         <translation>Schachfeldmuster bei Bildern mit Transparenz</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2163"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2184"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2977"/>
         <source>Expand images, up to:</source>
         <translation>Vergrößere Bilder, bis zu:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2271"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2292"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2979"/>
         <source>Images smaller than window will be zoomed in</source>
         <translation>Bilder kleiner als das Fenster werden vergrößert</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2323"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2344"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2980"/>
         <source>Zoom options</source>
         <translation>Skalierungsoptionen</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2330"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2351"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2981"/>
         <source>Unlock minimum zoom</source>
         <translation>Erlaube minimale Skalierung</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2340"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2361"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2982"/>
         <source>Always allow zooming below 100%</source>
         <translation>Erlaube immer unter 100% zu skalieren</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2365"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2386"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2983"/>
         <source>Zoom step:</source>
         <translation>Skalierungsschritte:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2433"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2454"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2984"/>
         <source>[step]</source>
         <translation>[Schritt]</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2462"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2483"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2985"/>
         <source>Use fixed zoom levels:</source>
         <translation>Benutze feste Skalierungsintervalle:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2506"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2527"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2986"/>
         <source>Load defaults</source>
         <translation>Lade Standardwerte</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2574"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2595"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2987"/>
         <source>Scaling quality</source>
         <translation>Skalierungsqualität</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2601"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2622"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2991"/>
         <source>Scaling filter:</source>
         <translation>Skalierungsfilter:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2633"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2654"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2992"/>
         <source>Nearest neighbor</source>
         <translation>Nearest Neighbor</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2638"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2659"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2993"/>
         <source>Bilinear</source>
         <translation>Bilinear</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2680"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2701"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2999"/>
         <source>When unchecked, nearest neighbor algorithm will be used for upscaling.</source>
         <translation>Falls nicht ausgewählt, wird Nearest Neighbour für die Vergrößerung benutzt.</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2683"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2704"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3001"/>
         <source>Smooth upscaling</source>
         <translation>Geschmeidiges Hochskalieren</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2702"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2723"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3002"/>
         <source>Smooth animated images</source>
         <translation>Bewegtbilder glätten</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2781"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2802"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3003"/>
         <source>Theme</source>
         <translation>Thema</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2840"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2861"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3004"/>
         <source>Load preset:</source>
         <translation>Voreinstellung laden:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2853"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2857"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2874"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2878"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3005"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3010"/>
         <source>Black</source>
         <translation>Schwarz</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2862"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2883"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3006"/>
         <source>Dark</source>
         <translation>Dunkel</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2867"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2888"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3007"/>
         <source>Dark Blue</source>
         <translation>Dunkelblau</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2872"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2893"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3008"/>
         <source>Light</source>
         <translation>Hell</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2896"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2917"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3011"/>
         <source>Use system colors</source>
         <translation>Betriebssystemsfarben</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2906"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2927"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3012"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;modify&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translatorcomment>???</translatorcomment>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3132"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3153"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3015"/>
         <source>Accent</source>
         <translation>Akzent</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3139"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3160"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3016"/>
         <source>Background</source>
         <translation>Hintergrund</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3146"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3167"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3017"/>
         <source>Background (fullscreen mode)</source>
         <translation>Hintergrund (Vollbildmodus)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3184"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3205"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3019"/>
         <source>Text</source>
         <translation>Text</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3191"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3212"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3020"/>
         <source>Icons</source>
         <translation>Symbole</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3291"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3312"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3024"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="62"/>
         <source>Overlay background</source>
         <translation>Overlay Hintergrund</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3329"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3350"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3026"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="60"/>
         <source>Widget background</source>
         <translation>Widget Hintergrund</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3336"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3357"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3027"/>
         <source>Folder view top panel</source>
         <translation>Ordneransicht oberes Panel</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3343"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3364"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3028"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="61"/>
         <source>Widget border</source>
         <translation>Widget Rand</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3412"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3433"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3031"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="63"/>
         <source>Overlay text</source>
         <translation>Overlay Text</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3450"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3471"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3033"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="64"/>
         <source>Scrollbars</source>
         <translation>Bildlaufleiste</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3457"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3478"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3034"/>
         <source>Folder view background</source>
         <translation>Ordneransicht Hintergrund</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3528"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3549"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3035"/>
         <source>Other window tweaks</source>
         <translation>Andere Fensteranpassungen</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3543"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3564"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3036"/>
         <source>Window opacity:</source>
         <translation>Fensterdurchsichtigkeit:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3596"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3617"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3037"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3621"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3642"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3038"/>
         <source>Background blur (KDE)</source>
         <translation>Hintergrundverschwommenheit (KDE)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3673"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3694"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3039"/>
         <source>Controls</source>
         <translation>Steuerung</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3734"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4073"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3755"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4200"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3040"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3063"/>
         <source>Add</source>
         <translation>Hinzufügen</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3741"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4080"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3762"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4207"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3041"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3064"/>
         <source>Edit</source>
         <translation>Bearbeiten</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3754"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4087"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3775"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4214"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3042"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3065"/>
         <source>Remove</source>
         <translation>Entfernen</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3783"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3804"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3043"/>
         <source>Reset to defaults</source>
         <translation>Zurücksetzen zum Standard</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3817"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3838"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3045"/>
         <source>Action</source>
         <translation>Aktion</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3822"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3843"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3047"/>
         <source>Shortcut</source>
         <translation>Tastenkombination</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3874"/>
-        <source>Mouse &amp; touchpad</source>
-        <translation>Maus und TouchPad</translation>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3898"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3048"/>
+        <source>Switch image by clicking window edges</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3895"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3905"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3049"/>
+        <source>Visible edges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mouse &amp; touchpad</source>
+        <translation type="vanished">Maus und TouchPad</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3935"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3050"/>
         <source>Scroll image with:</source>
         <translation>Scrolle Bilder mit:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3903"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3943"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3051"/>
         <source>None</source>
         <translation>Nichts</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3908"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3948"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3052"/>
         <source>Touchpad</source>
         <translation>Touchpad</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3913"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3953"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3053"/>
         <source>Touchpad &amp; Mouse Wheel</source>
         <translation>Touchpad und Mausrad</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3939"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3979"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3055"/>
         <source>Note: you can also zoom by holding RMB and moving the mouse</source>
         <translation>Hinweis: Sie können auch mit Rechsklick und Bewegen der Maus die Größe ändern</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3953"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4007"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3056"/>
+        <source>Mouse scrolling speed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4051"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3057"/>
+        <source>[x]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4080"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3058"/>
         <source>Trackpad detection</source>
         <translation>Trackpaderkennung</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3963"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4090"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3059"/>
         <source>Disable if you have issues with mouse scrolling</source>
         <translation>Deaktivieren wenn Sie Probleme mit dem Mausscrollen haben</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3995"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4122"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3060"/>
         <source>Scripts</source>
         <translation>Skripte</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4051"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4178"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3061"/>
         <source>Note: these will appear in &quot;Open with&quot; menu.</source>
         <translation>Hinweis: Diese werden auch im Kontextmenü erscheinen.</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4061"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4188"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3062"/>
         <source>Also, you can assign shortcuts to scripts (in &quot;Controls&quot; section).</source>
         <translation>Sie können auch Tastenkombinationen den Skripten zuweisen (siehe &quot;Steuerung&quot;).</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4170"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4297"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3066"/>
         <source>Advanced</source>
         <translation>Fortgeschritten</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4227"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4354"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3068"/>
         <source>Preload the next/previous image. Results in a much faster image switching (at the expense of wasting more RAM).</source>
         <translation>Lade das nächste/vorherige Bild vor. Ergibt einen viel schnelleren Bildwechsel (benötigt aber mehr Arbeitsspeicher).</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4230"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4357"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3070"/>
         <source>Use preloader (recommended)</source>
         <translation>Nutze den Preloader (empfohlen)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4240"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4367"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3071"/>
         <source>Load adjacent images in background</source>
         <translation>Lade angrenzende Bilder im Hintergrund</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4268"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4395"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3072"/>
         <source>Thumbnailer thread count:</source>
         <translation>Anzahl an Thumbnailerthreads:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4306"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4433"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3073"/>
         <source>2</source>
         <translation>2</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4337"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4464"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3077"/>
         <source>Use thumbnail cache (recommended)</source>
         <translation>Benutze einen Thumbnailcache (empfohlen)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4344"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4471"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3078"/>
         <source>Unload off-screen thumbnails</source>
         <translation>Entlade Thumbnails außerhalb des Bildschirms</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4354"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4481"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3079"/>
         <source>Dynamically unload items to save memory</source>
         <translation>Entlade Elemente dynamisch um RAM zu sparen</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4368"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4495"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3080"/>
         <source>Show save overlay when editing images</source>
         <translation>Zeige Speicheroverlay beim Bearbeiten</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4383"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4510"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3081"/>
         <source>JPEG save quality:</source>
         <translation>JPEG-Qualität beim Speichern:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4427"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4554"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3082"/>
         <source>q</source>
         <translation>q</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4456"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4583"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3083"/>
         <source>Confirm moving to trash</source>
         <translation>Bestätige um in den Papierkorb zu schieben</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4468"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4595"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3084"/>
         <source>Confirm file delete (!)</source>
         <translation>Bestätige um Dateien zu löschen (!)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4482"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4609"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3085"/>
         <source>JXL animation support (experimental)</source>
         <translation>Support für JXL-Animationen (experimentell)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4510"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4637"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3086"/>
         <source>Memory allocation limit per image, MB:</source>
         <translation>Maximale Speichernutzung pro Bild, MB:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4571"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4698"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3087"/>
         <source>Mpv binary:</source>
         <translation>Mpv Pfad:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4612"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4739"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3088"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4706"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4833"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3089"/>
         <source>About qimgv</source>
         <translation>Über qimgv</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4757"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4884"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3090"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -1917,17 +2208,20 @@ li.checked::marker { content: &quot;\2612&quot;; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:10pt;&quot;&gt;Jegliche Probleme und Anregungen können &lt;/span&gt;&lt;a href=&quot;https://github.com/easymodo/qimgv/issues&quot;&gt;&lt;span style=&quot; font-family:&apos;Droid Sans&apos;; font-size:10pt; text-decoration: underline; color:#007af4;&quot;&gt;hier&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:10pt;&quot;&gt; abgegeben werden.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4850"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4977"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3112"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4857"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4984"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3113"/>
         <source>Apply</source>
         <translation>Anwenden</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4864"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4991"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3114"/>
         <source>Cancel</source>
         <translation>Abbruch</translation>
     </message>
@@ -1967,40 +2261,50 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>Textfarbe</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.cpp" line="569"/>
+        <location filename="../../gui/dialogs/settingsdialog.cpp" line="590"/>
         <source>Edit shortcut</source>
         <translation>Bearbeite Tastenkombination</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.cpp" line="620"/>
+        <location filename="../../gui/dialogs/settingsdialog.cpp" line="641"/>
         <source>Navigate to mpv binary</source>
         <translation>Gehe zur mpv-Datei</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.cpp" line="649"/>
+        <source>Maximum</source>
+        <translation>Maximum</translation>
     </message>
 </context>
 <context>
     <name>ShortcutCreatorDialog</name>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="14"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="148"/>
         <source>New shortcut</source>
         <translation>Neue Tastenkombination</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="34"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="149"/>
         <source>Action:</source>
         <translation>Aktion:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="73"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="150"/>
         <source>Script:</source>
         <translation>Skript:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="117"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="151"/>
         <source>Shortcut:</source>
         <translation>Tastenkombination:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="124"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="152"/>
         <source>[Enter shortcut]</source>
         <translation>[Tastenkombination eingeben]</translation>
     </message>
@@ -2008,32 +2312,32 @@ li.checked::marker { content: &quot;\2612&quot;; }
 <context>
     <name>main</name>
     <message>
-        <location filename="../../main.cpp" line="133"/>
+        <location filename="../../main.cpp" line="126"/>
         <source>File or directory path.</source>
         <translation>Pfad zur Datei oder Verzeichnis.</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="136"/>
+        <location filename="../../main.cpp" line="129"/>
         <source>Generate all thumbnails for directory.</source>
         <translation>Erzeuge alle Vorschaubilder für das Verzeichnis.</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="137"/>
+        <location filename="../../main.cpp" line="130"/>
         <source>directory-path</source>
         <translation>Verzeichnispfad</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="139"/>
+        <location filename="../../main.cpp" line="132"/>
         <source>Thumbnail size. Current size is used if not specified.</source>
         <translation>Vorschaubildgröße. Aktuelle Größe wird genutzt falls nicht angegeben.</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="140"/>
+        <location filename="../../main.cpp" line="133"/>
         <source>thumbnail-size</source>
         <translation>Vorschaubildgröße</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="142"/>
+        <location filename="../../main.cpp" line="135"/>
         <source>Show build options.</source>
         <translatorcomment>If I translate build, I fear no one will know what is meant. Programming related terms in Germany are inherently mixed German and English</translatorcomment>
         <translation>Zeige Build-Optionen.</translation>

--- a/qimgv/res/translations/en_US.ts
+++ b/qimgv/res/translations/en_US.ts
@@ -5,11 +5,13 @@
     <name>ChangelogWindow</name>
     <message>
         <location filename="../../gui/overlays/changelogwindow.ui" line="154"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_changelogwindow.h" line="137"/>
         <source>Close, never show changelogs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/overlays/changelogwindow.ui" line="170"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_changelogwindow.h" line="138"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17,62 +19,63 @@
 <context>
     <name>ContextMenu</name>
     <message>
-        <location filename="../../gui/contextmenu.ui" line="229"/>
+        <location filename="../../gui/contextmenu.ui" line="236"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_contextmenu.h" line="449"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="55"/>
+        <location filename="../../gui/contextmenu.cpp" line="58"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="59"/>
+        <location filename="../../gui/contextmenu.cpp" line="62"/>
         <source>Quick copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="63"/>
+        <location filename="../../gui/contextmenu.cpp" line="66"/>
         <source>Quick move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="67"/>
+        <location filename="../../gui/contextmenu.cpp" line="70"/>
         <source>Move to trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="72"/>
+        <location filename="../../gui/contextmenu.cpp" line="75"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="77"/>
+        <location filename="../../gui/contextmenu.cpp" line="80"/>
         <source>Folder View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="82"/>
+        <location filename="../../gui/contextmenu.cpp" line="85"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="85"/>
+        <location filename="../../gui/contextmenu.cpp" line="88"/>
         <source>Open with...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="91"/>
+        <location filename="../../gui/contextmenu.cpp" line="94"/>
         <source>Show in folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="99"/>
+        <location filename="../../gui/contextmenu.cpp" line="102"/>
         <source>Back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="102"/>
+        <location filename="../../gui/contextmenu.cpp" line="105"/>
         <source>Configure menu</source>
         <translation type="unfinished"></translation>
     </message>
@@ -94,228 +97,228 @@
 <context>
     <name>Core</name>
     <message>
-        <location filename="../../core.cpp" line="255"/>
+        <location filename="../../core.cpp" line="258"/>
         <source>Updated: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="261"/>
+        <location filename="../../core.cpp" line="264"/>
         <source>Welcome to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="261"/>
+        <location filename="../../core.cpp" line="264"/>
         <source> version </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="268"/>
+        <location filename="../../core.cpp" line="271"/>
         <source>Shuffle mode: OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="271"/>
+        <location filename="../../core.cpp" line="274"/>
         <source>Shuffle mode: ON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="280"/>
+        <location filename="../../core.cpp" line="283"/>
         <source>Slideshow: OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="284"/>
+        <location filename="../../core.cpp" line="287"/>
         <source>Slideshow: ON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="355"/>
+        <location filename="../../core.cpp" line="358"/>
         <source>Delete </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="355"/>
+        <location filename="../../core.cpp" line="358"/>
         <source> items permanently?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="357"/>
+        <location filename="../../core.cpp" line="360"/>
         <source>Delete item permanently?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="358"/>
+        <location filename="../../core.cpp" line="361"/>
         <source>Delete permanently</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="374"/>
+        <location filename="../../core.cpp" line="377"/>
         <source>File removed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="378"/>
+        <location filename="../../core.cpp" line="381"/>
         <source>Removed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="378"/>
-        <location filename="../../core.cpp" line="408"/>
+        <location filename="../../core.cpp" line="381"/>
+        <location filename="../../core.cpp" line="411"/>
         <source> files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="389"/>
+        <location filename="../../core.cpp" line="392"/>
         <source>Move </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="389"/>
+        <location filename="../../core.cpp" line="392"/>
         <source> items to trash?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="391"/>
+        <location filename="../../core.cpp" line="394"/>
         <source>Move item to trash?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="392"/>
+        <location filename="../../core.cpp" line="395"/>
         <source>Move to trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="404"/>
+        <location filename="../../core.cpp" line="407"/>
         <source>Moved to trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="408"/>
+        <location filename="../../core.cpp" line="411"/>
         <source>Moved to trash: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="463"/>
+        <location filename="../../core.cpp" line="466"/>
         <source>File copied</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="470"/>
+        <location filename="../../core.cpp" line="473"/>
         <source>Path copied</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="644"/>
-        <location filename="../../core.cpp" line="918"/>
-        <location filename="../../core.cpp" line="939"/>
+        <location filename="../../core.cpp" line="647"/>
+        <location filename="../../core.cpp" line="928"/>
+        <location filename="../../core.cpp" line="949"/>
         <source>File exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="644"/>
+        <location filename="../../core.cpp" line="647"/>
         <source>Overwrite file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="812"/>
-        <location filename="../../core.cpp" line="880"/>
+        <location filename="../../core.cpp" line="822"/>
+        <location filename="../../core.cpp" line="890"/>
         <source>Could not create directory </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="916"/>
+        <location filename="../../core.cpp" line="926"/>
         <source>File moved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="918"/>
-        <location filename="../../core.cpp" line="939"/>
+        <location filename="../../core.cpp" line="928"/>
+        <location filename="../../core.cpp" line="949"/>
         <source>Destination file exists. Overwrite?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="937"/>
+        <location filename="../../core.cpp" line="947"/>
         <source>File copied.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="984"/>
+        <location filename="../../core.cpp" line="994"/>
         <source>Perform action &quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="984"/>
+        <location filename="../../core.cpp" line="994"/>
         <source>Changes will be saved immediately.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1002"/>
+        <location filename="../../core.cpp" line="1012"/>
         <source>Flip horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1006"/>
+        <location filename="../../core.cpp" line="1016"/>
         <source>Flip vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1010"/>
+        <location filename="../../core.cpp" line="1020"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1014"/>
+        <location filename="../../core.cpp" line="1024"/>
         <source>Resize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1020"/>
-        <location filename="../../core.cpp" line="1026"/>
+        <location filename="../../core.cpp" line="1030"/>
+        <location filename="../../core.cpp" line="1036"/>
         <source>Crop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1058"/>
+        <location filename="../../core.cpp" line="1068"/>
         <source>File saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1061"/>
+        <location filename="../../core.cpp" line="1071"/>
         <source>Could not save file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1171"/>
+        <location filename="../../core.cpp" line="1181"/>
         <source>Could not open image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1175"/>
+        <location filename="../../core.cpp" line="1185"/>
         <source>Can only print static images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1226"/>
+        <location filename="../../core.cpp" line="1236"/>
         <source>Could not open path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1260"/>
+        <location filename="../../core.cpp" line="1270"/>
         <source>Could not load folder: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1413"/>
+        <location filename="../../core.cpp" line="1423"/>
         <source>End of directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1452"/>
+        <location filename="../../core.cpp" line="1462"/>
         <source>Load failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1496"/>
+        <location filename="../../core.cpp" line="1506"/>
         <source>Error: could not load image.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -324,76 +327,91 @@
     <name>CropPanel</name>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="107"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="370"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="125"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="371"/>
         <source>Width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="161"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="372"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="322"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="374"/>
         <source>Aspect Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="336"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="375"/>
         <source>Free</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="341"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="376"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="346"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="377"/>
         <source>Current Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="351"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="378"/>
         <source>This Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="356"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="379"/>
         <source>1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="361"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="380"/>
         <source>4:3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="366"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="381"/>
         <source>16:9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="371"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="382"/>
         <source>16:10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="499"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="385"/>
         <source>Crop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="512"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="386"/>
         <source>Crop &amp;&amp; Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="527"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="387"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -402,11 +420,13 @@
     <name>FVOptionsPopup</name>
     <message>
         <location filename="../../gui/folderview/fvoptionspopup.ui" line="32"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_fvoptionspopup.h" line="86"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/fvoptionspopup.ui" line="53"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_fvoptionspopup.h" line="87"/>
         <source>View options</source>
         <translation type="unfinished"></translation>
     </message>
@@ -415,56 +435,67 @@
     <name>FileReplaceDialog</name>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="14"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="130"/>
         <source>Dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="20"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="131"/>
         <source>title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="33"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="132"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="40"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="133"/>
         <source>src</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="50"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="134"/>
         <source>&gt;&gt;&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="63"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="135"/>
         <source>Destination:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="70"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="136"/>
         <source>dst</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="111"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="137"/>
         <source>Apply to all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="118"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="138"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="125"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="139"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="132"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="140"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -473,77 +504,93 @@
     <name>FolderView</name>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="17"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="410"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="145"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="411"/>
         <source>[path]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="195"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="413"/>
         <source>FolderViewSlider</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="242"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="416"/>
         <source>CheckableButton</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="274"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="426"/>
         <source>PanelComboBox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="281"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="418"/>
         <source>A - Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="286"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="419"/>
         <source>Z - A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="291"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="420"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="296"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="421"/>
         <source>Size (desc)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="301"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="422"/>
         <source>Oldest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="306"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="423"/>
         <source>Newest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="348"/>
         <location filename="../../gui/folderview/folderview.ui" line="373"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="429"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="432"/>
         <source>PanelButton</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="414"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="435"/>
         <source>PanelButtonRE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="476"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="438"/>
         <source>PlacesPanel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="532"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="440"/>
         <source>BOOKMARKS</source>
         <translation type="unfinished"></translation>
     </message>
@@ -551,11 +598,15 @@
         <location filename="../../gui/folderview/folderview.ui" line="551"/>
         <location filename="../../gui/folderview/folderview.ui" line="638"/>
         <location filename="../../gui/folderview/folderview.ui" line="657"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="442"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="446"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="449"/>
         <source>PlacesPanelButton</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="611"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="444"/>
         <source>FILESYSTEM</source>
         <translation type="unfinished"></translation>
     </message>
@@ -564,11 +615,13 @@
     <name>ImageInfoOverlay</name>
     <message>
         <location filename="../../gui/overlays/imageinfooverlay.ui" line="65"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_imageinfooverlay.h" line="111"/>
         <source>OverlayHeaderWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/overlays/imageinfooverlay.ui" line="99"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_imageinfooverlay.h" line="113"/>
         <source>EXIF Tags</source>
         <translation type="unfinished"></translation>
     </message>
@@ -584,35 +637,35 @@
 <context>
     <name>MW</name>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="565"/>
+        <location filename="../../gui/mainwindow.cpp" line="581"/>
         <source>Save File as...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="800"/>
+        <location filename="../../gui/mainwindow.cpp" line="816"/>
         <source>Folder view</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="801"/>
-        <location filename="../../gui/mainwindow.cpp" line="802"/>
-        <location filename="../../gui/mainwindow.cpp" line="805"/>
-        <location filename="../../gui/mainwindow.cpp" line="806"/>
+        <location filename="../../gui/mainwindow.cpp" line="817"/>
+        <location filename="../../gui/mainwindow.cpp" line="818"/>
+        <location filename="../../gui/mainwindow.cpp" line="821"/>
+        <location filename="../../gui/mainwindow.cpp" line="822"/>
         <source>No file opened.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="867"/>
+        <location filename="../../gui/mainwindow.cpp" line="883"/>
         <source>Fit Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="871"/>
+        <location filename="../../gui/mainwindow.cpp" line="887"/>
         <source>Fit Width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="875"/>
+        <location filename="../../gui/mainwindow.cpp" line="891"/>
         <source>Fit 1:1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -621,71 +674,85 @@
     <name>PrintDialog</name>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="20"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="304"/>
         <source>Print image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="126"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="306"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="179"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="307"/>
         <source>Printer:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="189"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="308"/>
         <source>&lt;No printers found&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="271"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="309"/>
         <source>Page orientation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="297"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="310"/>
         <source>Portrait</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="307"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="311"/>
         <source>Landscape</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="348"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="312"/>
         <source>Color mode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="374"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="313"/>
         <source>Grayscale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="384"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="314"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="409"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="315"/>
         <source>Fit to page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="434"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="316"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="454"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="317"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="464"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="318"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -825,11 +892,14 @@
     <message>
         <location filename="../../gui/overlays/renameoverlay.ui" line="171"/>
         <location filename="../../gui/overlays/renameoverlay.ui" line="260"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_renameoverlay.h" line="213"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_renameoverlay.h" line="214"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/overlays/renameoverlay.ui" line="273"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_renameoverlay.h" line="215"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -838,151 +908,181 @@
     <name>ResizeDialog</name>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="32"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="358"/>
         <source>Resize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="63"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="359"/>
         <source>By Percent:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="79"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="360"/>
         <source>By Absolute Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="98"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="361"/>
         <source>Percent:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="119"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="362"/>
         <source>Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="205"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="363"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="275"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="364"/>
         <source>Keep aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="304"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="365"/>
         <source>Filter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="330"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="366"/>
         <source>Nearest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="335"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="367"/>
         <source>Bilinear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="340"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="368"/>
         <source>Bicubic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="345"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="369"/>
         <source>Lanczos3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="358"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="371"/>
         <source>Common sizes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="392"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="372"/>
         <source>Select:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="397"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="373"/>
         <source>1366 x 768</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="402"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="374"/>
         <source>1440 x 900</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="407"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="375"/>
         <source>1440 x 1050</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="412"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="376"/>
         <source>1600 x 1200</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="417"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="377"/>
         <source>1920 x 1080 (FullHD)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="422"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="378"/>
         <source>1920 x 1200 (FullHD)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="427"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="379"/>
         <source>2560 x 1080</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="432"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="380"/>
         <source>2560 x 1440</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="437"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="381"/>
         <source>2560 x 1600</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="442"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="382"/>
         <source>3840 x 1600 (UW 4K)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="447"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="383"/>
         <source>3840 x 2160 (UHD-1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="470"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="385"/>
         <source>Fit to desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="489"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="386"/>
         <source>Fill desktop (expanding)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="508"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="387"/>
         <source>Reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="575"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="388"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="594"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="389"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1034,21 +1134,25 @@
     <name>SaveConfirmOverlay</name>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="81"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="145"/>
         <source>Unsaved edits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="127"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="146"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="140"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="147"/>
         <source>Save as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="169"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="148"/>
         <source>Discard</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1057,31 +1161,37 @@
     <name>ScriptEditorDialog</name>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="48"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="208"/>
         <source>Command:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="84"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="209"/>
         <source>NOTE: make sure your .sh script has execute flag.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="91"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="210"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="148"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="212"/>
         <source>Wait to finish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="218"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="214"/>
         <source>Create</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="225"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="215"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1126,752 +1236,930 @@
     <name>SettingsDialog</name>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="47"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2892"/>
         <source>Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="53"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2894"/>
         <source>SettingsDialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="339"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2900"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="415"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2901"/>
         <source>Language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="435"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2902"/>
         <source>Requires application restart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="473"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2903"/>
         <source>Open in fullscreen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="480"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2904"/>
         <source>Start in folder view by default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="551"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2905"/>
         <source>User interface</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="606"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2906"/>
         <source>Image info in window title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="626"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2907"/>
         <source>Auto-hide cursor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="633"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2909"/>
         <source>Turn this off if you are using a touchpad with libinput driver.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="636"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2911"/>
         <source>Enable smooth scrolling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="643"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2912"/>
         <source>Fullscreen info bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="656"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2913"/>
         <source>Status bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="689"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2914"/>
         <source>Zoom indicator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="699"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2915"/>
         <source>On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="706"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2916"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="713"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2917"/>
         <source>Auto</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="753"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2918"/>
         <source>Automatic window resize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="763"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2919"/>
         <source>Match displayed content</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="799"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2920"/>
         <source>Screen area limit for auto resize:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="864"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2240"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2261"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2921"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2978"/>
         <source>xx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="962"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2925"/>
         <source>Thumbnail panel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1018"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2926"/>
         <source>Crop previews</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1031"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2927"/>
         <source>Pinned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1050"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2928"/>
         <source>Disable in windowed mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1057"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2929"/>
         <source>Center selected image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1109"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2930"/>
         <source>Extended</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1119"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2931"/>
         <source>Previews only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1126"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2932"/>
         <source>Display style:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1139"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2933"/>
         <source>Show filename and resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1159"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2934"/>
         <source>Simple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1183"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2935"/>
         <source>Preview size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1258"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2936"/>
         <source>Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1266"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2064"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2085"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2937"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2972"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1271"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2938"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1276"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2939"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1281"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2940"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1374"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2942"/>
         <source>Folder navigation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1400"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2943"/>
         <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1410"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2944"/>
         <source>Loop folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1417"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2945"/>
         <source>Go to the next folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1424"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2946"/>
         <source>After reaching the end:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1476"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2947"/>
         <source>Default sorting mode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1493"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2948"/>
         <source>A - Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1498"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2949"/>
         <source>Z - A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1503"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2950"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1508"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2951"/>
         <source>Size (desc)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1513"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2952"/>
         <source>Oldest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1518"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2953"/>
         <source>Newest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1541"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2955"/>
         <source>Apply sorting to folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1609"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1555"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2956"/>
+        <source>Show hidden files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1623"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2957"/>
         <source>Video playback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1651"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1665"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2958"/>
         <source>Play sounds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1720"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1734"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2959"/>
         <source>Slideshow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1740"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1754"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2960"/>
         <source>Switch interval:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1771"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1785"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2961"/>
         <source>ms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1803"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1817"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2962"/>
         <source>Loop slideshow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1900"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1914"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2963"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1956"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1970"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2964"/>
         <source>Display options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1980"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1994"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2965"/>
         <source>Image fit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1987"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2001"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2966"/>
         <source>Fit in window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1997"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2011"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2967"/>
         <source>Stretch to width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2004"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2018"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2968"/>
         <source>1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="2025"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2969"/>
         <source>Fit in window (stretch)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2026"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2047"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2970"/>
         <source>Keep fit mode when switching images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2057"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2078"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2971"/>
         <source>Focus in 1:1 mode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2071"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2092"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2973"/>
         <source>Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2078"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2099"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2974"/>
         <source>At cursor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2103"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2124"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2975"/>
         <source>Part of image that&apos;s focused after switching to 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2126"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2147"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2976"/>
         <source>Grid background on images with transparency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2163"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2184"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2977"/>
         <source>Expand images, up to:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2271"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2292"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2979"/>
         <source>Images smaller than window will be zoomed in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2323"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2344"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2980"/>
         <source>Zoom options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2330"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2351"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2981"/>
         <source>Unlock minimum zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2340"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2361"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2982"/>
         <source>Always allow zooming below 100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2365"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2386"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2983"/>
         <source>Zoom step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2433"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2454"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2984"/>
         <source>[step]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2462"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2483"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2985"/>
         <source>Use fixed zoom levels:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2506"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2527"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2986"/>
         <source>Load defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2574"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2595"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2987"/>
         <source>Scaling quality</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2601"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2622"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2991"/>
         <source>Scaling filter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2633"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2654"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2992"/>
         <source>Nearest neighbor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2638"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2659"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2993"/>
         <source>Bilinear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2680"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2701"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2999"/>
         <source>When unchecked, nearest neighbor algorithm will be used for upscaling.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2683"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2704"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3001"/>
         <source>Smooth upscaling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2702"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2723"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3002"/>
         <source>Smooth animated images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2781"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2802"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3003"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2840"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2861"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3004"/>
         <source>Load preset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2853"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2857"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2874"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2878"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3005"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3010"/>
         <source>Black</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2862"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2883"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3006"/>
         <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2867"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2888"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3007"/>
         <source>Dark Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2872"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2893"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3008"/>
         <source>Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2896"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2917"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3011"/>
         <source>Use system colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2906"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2927"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3012"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;modify&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3132"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3153"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3015"/>
         <source>Accent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3139"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3160"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3016"/>
         <source>Background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3146"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3167"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3017"/>
         <source>Background (fullscreen mode)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3184"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3205"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3019"/>
         <source>Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3191"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3212"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3020"/>
         <source>Icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3291"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3312"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3024"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="62"/>
         <source>Overlay background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3329"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3350"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3026"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="60"/>
         <source>Widget background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3336"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3357"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3027"/>
         <source>Folder view top panel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3343"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3364"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3028"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="61"/>
         <source>Widget border</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3412"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3433"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3031"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="63"/>
         <source>Overlay text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3450"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3471"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3033"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="64"/>
         <source>Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3457"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3478"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3034"/>
         <source>Folder view background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3528"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3549"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3035"/>
         <source>Other window tweaks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3543"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3564"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3036"/>
         <source>Window opacity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3596"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3617"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3037"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3621"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3642"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3038"/>
         <source>Background blur (KDE)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3673"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3694"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3039"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3734"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4073"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3755"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4200"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3040"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3063"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3741"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4080"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3762"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4207"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3041"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3064"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3754"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4087"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3775"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4214"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3042"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3065"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3783"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3804"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3043"/>
         <source>Reset to defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3817"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3838"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3045"/>
         <source>Action</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3822"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3843"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3047"/>
         <source>Shortcut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3874"/>
-        <source>Mouse &amp; touchpad</source>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3898"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3048"/>
+        <source>Switch image by clicking window edges</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3895"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3905"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3049"/>
+        <source>Visible edges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3935"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3050"/>
         <source>Scroll image with:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3903"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3943"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3051"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3908"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3948"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3052"/>
         <source>Touchpad</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3913"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3953"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3053"/>
         <source>Touchpad &amp; Mouse Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3939"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3979"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3055"/>
         <source>Note: you can also zoom by holding RMB and moving the mouse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3953"/>
-        <source>Trackpad detection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3963"/>
-        <source>Disable if you have issues with mouse scrolling</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3995"/>
-        <source>Scripts</source>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4007"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3056"/>
+        <source>Mouse scrolling speed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="4051"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3057"/>
+        <source>[x]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4080"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3058"/>
+        <source>Trackpad detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4090"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3059"/>
+        <source>Disable if you have issues with mouse scrolling</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4122"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3060"/>
+        <source>Scripts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4178"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3061"/>
         <source>Note: these will appear in &quot;Open with&quot; menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4061"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4188"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3062"/>
         <source>Also, you can assign shortcuts to scripts (in &quot;Controls&quot; section).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4170"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4297"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3066"/>
         <source>Advanced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4227"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4354"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3068"/>
         <source>Preload the next/previous image. Results in a much faster image switching (at the expense of wasting more RAM).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4230"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4357"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3070"/>
         <source>Use preloader (recommended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4240"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4367"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3071"/>
         <source>Load adjacent images in background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4268"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4395"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3072"/>
         <source>Thumbnailer thread count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4306"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4433"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3073"/>
         <source>2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4337"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4464"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3077"/>
         <source>Use thumbnail cache (recommended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4344"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4471"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3078"/>
         <source>Unload off-screen thumbnails</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4354"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4481"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3079"/>
         <source>Dynamically unload items to save memory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4368"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4495"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3080"/>
         <source>Show save overlay when editing images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4383"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4510"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3081"/>
         <source>JPEG save quality:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4427"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4554"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3082"/>
         <source>q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4456"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4583"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3083"/>
         <source>Confirm moving to trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4468"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4595"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3084"/>
         <source>Confirm file delete (!)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4482"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4609"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3085"/>
         <source>JXL animation support (experimental)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4510"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4637"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3086"/>
         <source>Memory allocation limit per image, MB:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4571"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4698"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3087"/>
         <source>Mpv binary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4612"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4739"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3088"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4706"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4833"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3089"/>
         <source>About qimgv</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4757"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4884"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3090"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -1893,17 +2181,20 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4850"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4977"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3112"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4857"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4984"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3113"/>
         <source>Apply</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4864"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4991"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3114"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1943,13 +2234,18 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.cpp" line="569"/>
+        <location filename="../../gui/dialogs/settingsdialog.cpp" line="590"/>
         <source>Edit shortcut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.cpp" line="620"/>
+        <location filename="../../gui/dialogs/settingsdialog.cpp" line="641"/>
         <source>Navigate to mpv binary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.cpp" line="649"/>
+        <source>Maximum</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1957,26 +2253,31 @@ li.checked::marker { content: &quot;\2612&quot;; }
     <name>ShortcutCreatorDialog</name>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="14"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="148"/>
         <source>New shortcut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="34"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="149"/>
         <source>Action:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="73"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="150"/>
         <source>Script:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="117"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="151"/>
         <source>Shortcut:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="124"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="152"/>
         <source>[Enter shortcut]</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1984,32 +2285,32 @@ li.checked::marker { content: &quot;\2612&quot;; }
 <context>
     <name>main</name>
     <message>
-        <location filename="../../main.cpp" line="133"/>
+        <location filename="../../main.cpp" line="126"/>
         <source>File or directory path.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="136"/>
+        <location filename="../../main.cpp" line="129"/>
         <source>Generate all thumbnails for directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="137"/>
+        <location filename="../../main.cpp" line="130"/>
         <source>directory-path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="139"/>
+        <location filename="../../main.cpp" line="132"/>
         <source>Thumbnail size. Current size is used if not specified.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="140"/>
+        <location filename="../../main.cpp" line="133"/>
         <source>thumbnail-size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="142"/>
+        <location filename="../../main.cpp" line="135"/>
         <source>Show build options.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/qimgv/res/translations/es_ES.ts
+++ b/qimgv/res/translations/es_ES.ts
@@ -5,11 +5,13 @@
     <name>ChangelogWindow</name>
     <message>
         <location filename="../../gui/overlays/changelogwindow.ui" line="154"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_changelogwindow.h" line="137"/>
         <source>Close, never show changelogs</source>
         <translation type="unfinished">Cerrar y no mostrar más</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/changelogwindow.ui" line="170"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_changelogwindow.h" line="138"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
@@ -17,62 +19,63 @@
 <context>
     <name>ContextMenu</name>
     <message>
-        <location filename="../../gui/contextmenu.ui" line="229"/>
+        <location filename="../../gui/contextmenu.ui" line="236"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_contextmenu.h" line="449"/>
         <source>Edit</source>
         <translation>Editar</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="55"/>
+        <location filename="../../gui/contextmenu.cpp" line="58"/>
         <source>Print</source>
         <translation>Imprimir</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="59"/>
+        <location filename="../../gui/contextmenu.cpp" line="62"/>
         <source>Quick copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="63"/>
+        <location filename="../../gui/contextmenu.cpp" line="66"/>
         <source>Quick move</source>
         <translation>Renombrar</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="67"/>
+        <location filename="../../gui/contextmenu.cpp" line="70"/>
         <source>Move to trash</source>
         <translation>Enviar a la papelera</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="72"/>
+        <location filename="../../gui/contextmenu.cpp" line="75"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="77"/>
+        <location filename="../../gui/contextmenu.cpp" line="80"/>
         <source>Folder View</source>
         <translation>Vista de Carpetas</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="82"/>
+        <location filename="../../gui/contextmenu.cpp" line="85"/>
         <source>Settings</source>
         <translation>Preferencias</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="85"/>
+        <location filename="../../gui/contextmenu.cpp" line="88"/>
         <source>Open with...</source>
         <translation>Abrir con...</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="91"/>
+        <location filename="../../gui/contextmenu.cpp" line="94"/>
         <source>Show in folder</source>
         <translation>Mostrar en carpeta</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="99"/>
+        <location filename="../../gui/contextmenu.cpp" line="102"/>
         <source>Back</source>
         <translation>Atras</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="102"/>
+        <location filename="../../gui/contextmenu.cpp" line="105"/>
         <source>Configure menu</source>
         <translation>Menu de configuracion</translation>
     </message>
@@ -94,228 +97,228 @@
 <context>
     <name>Core</name>
     <message>
-        <location filename="../../core.cpp" line="255"/>
+        <location filename="../../core.cpp" line="258"/>
         <source>Updated: </source>
         <translation>Actualizado: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="261"/>
+        <location filename="../../core.cpp" line="264"/>
         <source>Welcome to </source>
         <translation>Bienvenido a </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="261"/>
+        <location filename="../../core.cpp" line="264"/>
         <source> version </source>
         <translation> versión </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="268"/>
+        <location filename="../../core.cpp" line="271"/>
         <source>Shuffle mode: OFF</source>
         <translation>Modo aleatorio: Apagado</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="271"/>
+        <location filename="../../core.cpp" line="274"/>
         <source>Shuffle mode: ON</source>
         <translation>Modo aleatorio: Encendido</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="280"/>
+        <location filename="../../core.cpp" line="283"/>
         <source>Slideshow: OFF</source>
         <translation>Diapositivas: Apagado</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="284"/>
+        <location filename="../../core.cpp" line="287"/>
         <source>Slideshow: ON</source>
         <translation>Diapositivas: Encendido</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="355"/>
+        <location filename="../../core.cpp" line="358"/>
         <source>Delete </source>
         <translation>Eliminar </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="355"/>
+        <location filename="../../core.cpp" line="358"/>
         <source> items permanently?</source>
         <translation> ítems permanentemente?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="357"/>
+        <location filename="../../core.cpp" line="360"/>
         <source>Delete item permanently?</source>
         <translation>Eliminar permanentemente?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="358"/>
+        <location filename="../../core.cpp" line="361"/>
         <source>Delete permanently</source>
         <translation>Eliminar permanentemente</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="374"/>
+        <location filename="../../core.cpp" line="377"/>
         <source>File removed</source>
         <translation>Archivo eliminado</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="378"/>
+        <location filename="../../core.cpp" line="381"/>
         <source>Removed: </source>
         <translation>Eliminado: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="378"/>
-        <location filename="../../core.cpp" line="408"/>
+        <location filename="../../core.cpp" line="381"/>
+        <location filename="../../core.cpp" line="411"/>
         <source> files</source>
         <translation> archivos</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="389"/>
+        <location filename="../../core.cpp" line="392"/>
         <source>Move </source>
         <translation>Mover </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="389"/>
+        <location filename="../../core.cpp" line="392"/>
         <source> items to trash?</source>
         <translation> ítems a la papelera?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="391"/>
+        <location filename="../../core.cpp" line="394"/>
         <source>Move item to trash?</source>
         <translation>Mover ítem a la papelera?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="392"/>
+        <location filename="../../core.cpp" line="395"/>
         <source>Move to trash</source>
         <translation>Mover a la papelera</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="404"/>
+        <location filename="../../core.cpp" line="407"/>
         <source>Moved to trash</source>
         <translation>Movido a la papelera</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="408"/>
+        <location filename="../../core.cpp" line="411"/>
         <source>Moved to trash: </source>
         <translation>Movido a la papelera: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="463"/>
+        <location filename="../../core.cpp" line="466"/>
         <source>File copied</source>
         <translation>Archivo copiado</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="470"/>
+        <location filename="../../core.cpp" line="473"/>
         <source>Path copied</source>
         <translation>Ruta copiada</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="644"/>
-        <location filename="../../core.cpp" line="918"/>
-        <location filename="../../core.cpp" line="939"/>
+        <location filename="../../core.cpp" line="647"/>
+        <location filename="../../core.cpp" line="928"/>
+        <location filename="../../core.cpp" line="949"/>
         <source>File exists</source>
         <translation>Archivo existente</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="644"/>
+        <location filename="../../core.cpp" line="647"/>
         <source>Overwrite file?</source>
         <translation>Sobre escribir archivo?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="812"/>
-        <location filename="../../core.cpp" line="880"/>
+        <location filename="../../core.cpp" line="822"/>
+        <location filename="../../core.cpp" line="890"/>
         <source>Could not create directory </source>
         <translation>No se pudo crear la carpeta </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="916"/>
+        <location filename="../../core.cpp" line="926"/>
         <source>File moved.</source>
         <translation>Archivo movido.</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="918"/>
-        <location filename="../../core.cpp" line="939"/>
+        <location filename="../../core.cpp" line="928"/>
+        <location filename="../../core.cpp" line="949"/>
         <source>Destination file exists. Overwrite?</source>
         <translation>El archivo de destino existe. Sobre escribe?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="937"/>
+        <location filename="../../core.cpp" line="947"/>
         <source>File copied.</source>
         <translation>Archivo copiado.</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="984"/>
+        <location filename="../../core.cpp" line="994"/>
         <source>Perform action &quot;</source>
         <translation>Ejecutar acción &quot;</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="984"/>
+        <location filename="../../core.cpp" line="994"/>
         <source>Changes will be saved immediately.</source>
         <translation>Los cambios serán guardados inmediatamente.</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1002"/>
+        <location filename="../../core.cpp" line="1012"/>
         <source>Flip horizontal</source>
         <translation>Voltear horizontalmente</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1006"/>
+        <location filename="../../core.cpp" line="1016"/>
         <source>Flip vertical</source>
         <translation>Voltear verticalmente</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1010"/>
+        <location filename="../../core.cpp" line="1020"/>
         <source>Rotate</source>
         <translation>Rotar</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1014"/>
+        <location filename="../../core.cpp" line="1024"/>
         <source>Resize</source>
         <translation>Cambiar tamaño</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1020"/>
-        <location filename="../../core.cpp" line="1026"/>
+        <location filename="../../core.cpp" line="1030"/>
+        <location filename="../../core.cpp" line="1036"/>
         <source>Crop</source>
         <translation>Recortar</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1058"/>
+        <location filename="../../core.cpp" line="1068"/>
         <source>File saved</source>
         <translation>Archivo grabado</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1061"/>
+        <location filename="../../core.cpp" line="1071"/>
         <source>Could not save file</source>
         <translation>No se pudo grabar el archivo</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1171"/>
+        <location filename="../../core.cpp" line="1181"/>
         <source>Could not open image</source>
         <translation>No se pudo abrir la imágen</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1175"/>
+        <location filename="../../core.cpp" line="1185"/>
         <source>Can only print static images</source>
         <translation>Solo se pueden imprimir imágenes estáticas</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1226"/>
+        <location filename="../../core.cpp" line="1236"/>
         <source>Could not open path: </source>
         <translation>No se pudo abrir la ruta: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1260"/>
+        <location filename="../../core.cpp" line="1270"/>
         <source>Could not load folder: </source>
         <translation>No se pudo cargar la carpeta: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1413"/>
+        <location filename="../../core.cpp" line="1423"/>
         <source>End of directory.</source>
         <translation>Fin de la carpeta.</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1452"/>
+        <location filename="../../core.cpp" line="1462"/>
         <source>Load failed: </source>
         <translation>Carga fallida: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1496"/>
+        <location filename="../../core.cpp" line="1506"/>
         <source>Error: could not load image.</source>
         <translation>Error: no se pudo cargar la imagen.</translation>
     </message>
@@ -324,76 +327,91 @@
     <name>CropPanel</name>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="107"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="370"/>
         <source>Selection</source>
         <translation>Seleccionar</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="125"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="371"/>
         <source>Width</source>
         <translation>Ancho</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="161"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="372"/>
         <source>Height</source>
         <translation>Altura</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="322"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="374"/>
         <source>Aspect Ratio</source>
         <translation>Relacion de aspecto</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="336"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="375"/>
         <source>Free</source>
         <translation>Libre</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="341"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="376"/>
         <source>Custom</source>
         <translation>Manual</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="346"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="377"/>
         <source>Current Image</source>
         <translation>Imagen actual</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="351"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="378"/>
         <source>This Screen</source>
         <translation>Esta pantalla</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="356"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="379"/>
         <source>1:1</source>
-        <translation></translation>
+        <translation type="unfinished">1:1</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="361"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="380"/>
         <source>4:3</source>
-        <translation></translation>
+        <translation type="unfinished">4:3</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="366"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="381"/>
         <source>16:9</source>
-        <translation></translation>
+        <translation type="unfinished">16:9</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="371"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="382"/>
         <source>16:10</source>
-        <translation></translation>
+        <translation type="unfinished">16:10</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="499"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="385"/>
         <source>Crop</source>
         <translation>Recortar</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="512"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="386"/>
         <source>Crop &amp;&amp; Save</source>
         <translation>Recortar y grabar</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="527"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="387"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -402,11 +420,13 @@
     <name>FVOptionsPopup</name>
     <message>
         <location filename="../../gui/folderview/fvoptionspopup.ui" line="32"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_fvoptionspopup.h" line="86"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/fvoptionspopup.ui" line="53"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_fvoptionspopup.h" line="87"/>
         <source>View options</source>
         <translation>Opciones de visualización</translation>
     </message>
@@ -415,56 +435,67 @@
     <name>FileReplaceDialog</name>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="14"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="130"/>
         <source>Dialog</source>
         <translation>Dialogo</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="20"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="131"/>
         <source>title</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="33"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="132"/>
         <source>Source:</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="40"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="133"/>
         <source>src</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="50"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="134"/>
         <source>&gt;&gt;&gt;</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="63"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="135"/>
         <source>Destination:</source>
         <translation>Destino:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="70"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="136"/>
         <source>dst</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="111"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="137"/>
         <source>Apply to all</source>
         <translation>Aplicar a todo</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="118"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="138"/>
         <source>Yes</source>
         <translation>Si</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="125"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="139"/>
         <source>No</source>
         <translation>No</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="132"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="140"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -473,77 +504,93 @@
     <name>FolderView</name>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="17"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="410"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="145"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="411"/>
         <source>[path]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="195"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="413"/>
         <source>FolderViewSlider</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="242"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="416"/>
         <source>CheckableButton</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="274"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="426"/>
         <source>PanelComboBox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="281"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="418"/>
         <source>A - Z</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="286"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="419"/>
         <source>Z - A</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="291"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="420"/>
         <source>Size</source>
         <translation>Tamaño</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="296"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="421"/>
         <source>Size (desc)</source>
         <translation>Tamaño (desc)</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="301"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="422"/>
         <source>Oldest</source>
         <translation>Más viejo</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="306"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="423"/>
         <source>Newest</source>
         <translation>Más nuevo</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="348"/>
         <location filename="../../gui/folderview/folderview.ui" line="373"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="429"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="432"/>
         <source>PanelButton</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="414"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="435"/>
         <source>PanelButtonRE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="476"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="438"/>
         <source>PlacesPanel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="532"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="440"/>
         <source>BOOKMARKS</source>
         <translation type="unfinished">Marcadores</translation>
     </message>
@@ -551,11 +598,15 @@
         <location filename="../../gui/folderview/folderview.ui" line="551"/>
         <location filename="../../gui/folderview/folderview.ui" line="638"/>
         <location filename="../../gui/folderview/folderview.ui" line="657"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="442"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="446"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="449"/>
         <source>PlacesPanelButton</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="611"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="444"/>
         <source>FILESYSTEM</source>
         <translation>Mi equipo</translation>
     </message>
@@ -564,11 +615,13 @@
     <name>ImageInfoOverlay</name>
     <message>
         <location filename="../../gui/overlays/imageinfooverlay.ui" line="65"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_imageinfooverlay.h" line="111"/>
         <source>OverlayHeaderWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/overlays/imageinfooverlay.ui" line="99"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_imageinfooverlay.h" line="113"/>
         <source>EXIF Tags</source>
         <translation type="unfinished"></translation>
     </message>
@@ -584,35 +637,35 @@
 <context>
     <name>MW</name>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="565"/>
+        <location filename="../../gui/mainwindow.cpp" line="581"/>
         <source>Save File as...</source>
         <translation>Guardar como...</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="800"/>
+        <location filename="../../gui/mainwindow.cpp" line="816"/>
         <source>Folder view</source>
         <translation>Vista de carpetas</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="801"/>
-        <location filename="../../gui/mainwindow.cpp" line="802"/>
-        <location filename="../../gui/mainwindow.cpp" line="805"/>
-        <location filename="../../gui/mainwindow.cpp" line="806"/>
+        <location filename="../../gui/mainwindow.cpp" line="817"/>
+        <location filename="../../gui/mainwindow.cpp" line="818"/>
+        <location filename="../../gui/mainwindow.cpp" line="821"/>
+        <location filename="../../gui/mainwindow.cpp" line="822"/>
         <source>No file opened.</source>
         <translation>No se abrió el archivo.</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="867"/>
+        <location filename="../../gui/mainwindow.cpp" line="883"/>
         <source>Fit Window</source>
         <translation>Encajar en la ventana</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="871"/>
+        <location filename="../../gui/mainwindow.cpp" line="887"/>
         <source>Fit Width</source>
         <translation>Encajar ancho</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="875"/>
+        <location filename="../../gui/mainwindow.cpp" line="891"/>
         <source>Fit 1:1</source>
         <translation>Proporción 1:1</translation>
     </message>
@@ -621,71 +674,85 @@
     <name>PrintDialog</name>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="20"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="304"/>
         <source>Print image</source>
         <translation>Imprimir imagen</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="126"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="306"/>
         <source>Preview</source>
         <translation>Previsualización</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="179"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="307"/>
         <source>Printer:</source>
         <translation>Impresora:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="189"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="308"/>
         <source>&lt;No printers found&gt;</source>
         <translation>&lt;Sin impresoras&gt;</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="271"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="309"/>
         <source>Page orientation:</source>
         <translation>Orientación de página:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="297"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="310"/>
         <source>Portrait</source>
         <translation>Vertical</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="307"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="311"/>
         <source>Landscape</source>
         <translation>Horizontal</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="348"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="312"/>
         <source>Color mode:</source>
         <translation>Modo de color:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="374"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="313"/>
         <source>Grayscale</source>
         <translation>Escala de grises</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="384"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="314"/>
         <source>Color</source>
         <translation>Color</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="409"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="315"/>
         <source>Fit to page</source>
         <translation>Encajar en la página</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="434"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="316"/>
         <source>Export PDF</source>
         <translation>Exportar a PDF</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="454"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="317"/>
         <source>Print</source>
         <translation>Imprimir</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="464"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="318"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -825,11 +892,14 @@
     <message>
         <location filename="../../gui/overlays/renameoverlay.ui" line="171"/>
         <location filename="../../gui/overlays/renameoverlay.ui" line="260"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_renameoverlay.h" line="213"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_renameoverlay.h" line="214"/>
         <source>Rename</source>
         <translation>Renombrar</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/renameoverlay.ui" line="273"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_renameoverlay.h" line="215"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -838,151 +908,181 @@
     <name>ResizeDialog</name>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="32"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="358"/>
         <source>Resize</source>
         <translation>Cambiar tamaño</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="63"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="359"/>
         <source>By Percent:</source>
         <translation>Por porcentaje:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="79"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="360"/>
         <source>By Absolute Size:</source>
         <translation>Por tamaño absoluto:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="98"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="361"/>
         <source>Percent:</source>
         <translation>Porcentaje:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="119"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="362"/>
         <source>Width:</source>
         <translation>Ancho:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="205"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="363"/>
         <source>Height:</source>
         <translation>Altura:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="275"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="364"/>
         <source>Keep aspect ratio</source>
         <translation>Mantener relacion de aspecto</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="304"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="365"/>
         <source>Filter:</source>
         <translation>Filtro:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="330"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="366"/>
         <source>Nearest</source>
         <translation type="unfinished">Más cercano</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="335"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="367"/>
         <source>Bilinear</source>
         <translation>Bilineal</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="340"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="368"/>
         <source>Bicubic</source>
         <translation>Bicubico</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="345"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="369"/>
         <source>Lanczos3</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="358"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="371"/>
         <source>Common sizes:</source>
         <translation>Tamaños comunes:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="392"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="372"/>
         <source>Select:</source>
         <translation>Seleccionar:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="397"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="373"/>
         <source>1366 x 768</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="402"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="374"/>
         <source>1440 x 900</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="407"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="375"/>
         <source>1440 x 1050</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="412"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="376"/>
         <source>1600 x 1200</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="417"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="377"/>
         <source>1920 x 1080 (FullHD)</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="422"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="378"/>
         <source>1920 x 1200 (FullHD)</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="427"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="379"/>
         <source>2560 x 1080</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="432"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="380"/>
         <source>2560 x 1440</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="437"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="381"/>
         <source>2560 x 1600</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="442"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="382"/>
         <source>3840 x 1600 (UW 4K)</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="447"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="383"/>
         <source>3840 x 2160 (UHD-1)</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="470"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="385"/>
         <source>Fit to desktop</source>
         <translation>Encajar al escritorio</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="489"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="386"/>
         <source>Fill desktop (expanding)</source>
         <translation>Rellenar escritorio (expandiendo)</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="508"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="387"/>
         <source>Reset</source>
         <translation>Resetear</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="575"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="388"/>
         <source>OK</source>
         <translation>Confirmar</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="594"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="389"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -1034,21 +1134,25 @@
     <name>SaveConfirmOverlay</name>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="81"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="145"/>
         <source>Unsaved edits</source>
         <translation>Cambios sin guardar</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="127"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="146"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="140"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="147"/>
         <source>Save as</source>
         <translation>Guardar como</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="169"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="148"/>
         <source>Discard</source>
         <translation>Descartar</translation>
     </message>
@@ -1057,31 +1161,37 @@
     <name>ScriptEditorDialog</name>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="48"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="208"/>
         <source>Command:</source>
         <translation>Comando:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="84"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="209"/>
         <source>NOTE: make sure your .sh script has execute flag.</source>
         <translation>NOTA: Asegúrese que el script sea ejecutable.</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="91"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="210"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="148"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="212"/>
         <source>Wait to finish</source>
         <translation>Esperar hasta finalizar</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="218"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="214"/>
         <source>Create</source>
         <translation>Crear</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="225"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="215"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -1126,752 +1236,946 @@
     <name>SettingsDialog</name>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="47"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2892"/>
         <source>Preferences</source>
         <translation>Preferencias</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="53"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2894"/>
         <source>SettingsDialog</source>
         <translation>Ventana de configuracion</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="339"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2900"/>
         <source>General</source>
-        <translation></translation>
+        <translation type="unfinished">General</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="415"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2901"/>
         <source>Language:</source>
         <translation>Idioma:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="435"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2902"/>
         <source>Requires application restart</source>
         <translation>Requiere reiniciar</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="473"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2903"/>
         <source>Open in fullscreen</source>
         <translation>Abrir en pantalla completa</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="480"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2904"/>
         <source>Start in folder view by default</source>
         <translation>Abrir por defecto en vista de carpetas</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="551"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2905"/>
         <source>User interface</source>
         <translation>Interfaz de usuario</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="606"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2906"/>
         <source>Image info in window title</source>
         <translation>Informacion de la imagen en barra de titulos</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="626"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2907"/>
         <source>Auto-hide cursor</source>
         <translation>Ocultar cursor automaticamente</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="633"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2909"/>
         <source>Turn this off if you are using a touchpad with libinput driver.</source>
         <translation>Desactivar si esta utilizando un panel táctil con el controlador de libimput.</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="636"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2911"/>
         <source>Enable smooth scrolling</source>
         <translation>Usar desplazamiento suave</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="643"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2912"/>
         <source>Fullscreen info bar</source>
         <translation>Barra de información en pantalla completa</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="656"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2913"/>
         <source>Status bar</source>
         <translation>Barra de estado</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="689"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2914"/>
         <source>Zoom indicator:</source>
         <translation>Indicador de zoom:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="699"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2915"/>
         <source>On</source>
         <translation>Encendido</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="706"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2916"/>
         <source>Off</source>
         <translation>Apagado</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="713"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2917"/>
         <source>Auto</source>
         <translation>Automático</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="753"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2918"/>
         <source>Automatic window resize</source>
         <translation>Redimensionar la ventana automáticamente</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="763"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2919"/>
         <source>Match displayed content</source>
         <translation>Ajustar al contenido mostrado</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="799"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2920"/>
         <source>Screen area limit for auto resize:</source>
         <translation>límite de pantalla para auto dimensionado:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="864"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2240"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2261"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2921"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2978"/>
         <source>xx</source>
         <translation>xx</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="962"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2925"/>
         <source>Thumbnail panel</source>
         <translation>Panel de miniaturas</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1018"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2926"/>
         <source>Crop previews</source>
         <translation>Recortar miniaturas</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1031"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2927"/>
         <source>Pinned</source>
         <translation>Fijo</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1050"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2928"/>
         <source>Disable in windowed mode</source>
         <translation>Desactivar en modo ventana</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1057"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2929"/>
         <source>Center selected image</source>
         <translation>Centrar la imagen seleccionada</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1109"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2930"/>
         <source>Extended</source>
         <translation>Extendido</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1119"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2931"/>
         <source>Previews only</source>
         <translation>Solo vistas previas</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1126"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2932"/>
         <source>Display style:</source>
         <translation>Estilo de visualización:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1139"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2933"/>
         <source>Show filename and resolution</source>
         <translation type="unfinished">Mostrar nombre y resolución</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1159"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2934"/>
         <source>Simple</source>
         <translation>Sencillo</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1183"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2935"/>
         <source>Preview size:</source>
         <translation>Tamaño de previsualización:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1258"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2936"/>
         <source>Position:</source>
         <translation>Ubicación:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1266"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2064"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2085"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2937"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2972"/>
         <source>Top</source>
         <translation>Arriba</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1271"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2938"/>
         <source>Bottom</source>
         <translation>Abajo</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1276"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2939"/>
         <source>Left</source>
         <translation>Izquierda</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1281"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2940"/>
         <source>Right</source>
         <translation>Derecha</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1374"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2942"/>
         <source>Folder navigation</source>
         <translation>Navegador de carpetas</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1400"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2943"/>
         <source>Stop</source>
         <translation>Detener</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1410"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2944"/>
         <source>Loop folder</source>
         <translation type="unfinished">Carpetas en bucle</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1417"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2945"/>
         <source>Go to the next folder</source>
         <translation>Ir a la siguiente carpeta</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1424"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2946"/>
         <source>After reaching the end:</source>
         <translation>Despues de alcanzar el final:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1476"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2947"/>
         <source>Default sorting mode:</source>
         <translation>Ordenamiento por defecto:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1493"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2948"/>
         <source>A - Z</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1498"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2949"/>
         <source>Z - A</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1503"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2950"/>
         <source>Size</source>
         <translation>Tamaño</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1508"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2951"/>
         <source>Size (desc)</source>
         <translation>Tamaño (descendiente)</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1513"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2952"/>
         <source>Oldest</source>
         <translation type="unfinished">Más viejo</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1518"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2953"/>
         <source>Newest</source>
         <translation type="unfinished">Más nuevo</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1541"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2955"/>
         <source>Apply sorting to folders</source>
         <translation>Aplicar ordenamiento a carpetar</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1609"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1555"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2956"/>
+        <source>Show hidden files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1623"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2957"/>
         <source>Video playback</source>
         <translation>Reproducción de vídeo</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1651"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1665"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2958"/>
         <source>Play sounds</source>
         <translation>Reproducir sonidos</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1720"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1734"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2959"/>
         <source>Slideshow</source>
         <translation>Diapositivas</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1740"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1754"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2960"/>
         <source>Switch interval:</source>
         <translation>Intervalo entre diapositivas:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1771"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1785"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2961"/>
         <source>ms</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1803"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1817"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2962"/>
         <source>Loop slideshow</source>
         <translation>Diapositivas en bucle</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1900"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1914"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2963"/>
         <source>View</source>
         <translation>Ver</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1956"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1970"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2964"/>
         <source>Display options</source>
         <translation>Opciones de visualización</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1980"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1994"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2965"/>
         <source>Image fit:</source>
         <translation>Encajar imagen:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1987"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2001"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2966"/>
         <source>Fit in window</source>
         <translation>Encajar en la ventana</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1997"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2011"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2967"/>
         <source>Stretch to width</source>
         <translation>Encajar al ancho</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2004"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2018"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2968"/>
         <source>1:1</source>
-        <translation></translation>
+        <translation type="unfinished">1:1</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="2025"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2969"/>
         <source>Fit in window (stretch)</source>
         <translation>Ajustar a ventana (estirar)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2026"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2047"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2970"/>
         <source>Keep fit mode when switching images</source>
         <translation>Mantener modo de encaje al cambiar de imagen</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2057"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2078"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2971"/>
         <source>Focus in 1:1 mode:</source>
         <translation>Enfoque en modo 1:1:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2071"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2092"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2973"/>
         <source>Center</source>
         <translation>Centrar</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2078"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2099"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2974"/>
         <source>At cursor</source>
         <translation>Sobre el cursor</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2103"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2124"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2975"/>
         <source>Part of image that&apos;s focused after switching to 1:1</source>
         <translation>Parte de la imagen enfocada después de cambiar a 1:1</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2126"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2147"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2976"/>
         <source>Grid background on images with transparency</source>
         <translation>Fondo de cuadrícula en imágenes con transparencia</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2163"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2184"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2977"/>
         <source>Expand images, up to:</source>
         <translation>Ampliar imágenes, hasta:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2271"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2292"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2979"/>
         <source>Images smaller than window will be zoomed in</source>
         <translation>Las imágenes más pequeñas que la ventana se ampliarán</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2323"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2344"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2980"/>
         <source>Zoom options</source>
         <translation>Opciones de zoom</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2330"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2351"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2981"/>
         <source>Unlock minimum zoom</source>
         <translation>Desbloquear zoom mínimo</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2340"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2361"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2982"/>
         <source>Always allow zooming below 100%</source>
         <translation>Permitir siempre hacer zoom por debajo del 100%</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2365"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2386"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2983"/>
         <source>Zoom step:</source>
         <translation>Paso de zoom:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2433"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2454"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2984"/>
         <source>[step]</source>
         <translation>[salto]</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2462"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2483"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2985"/>
         <source>Use fixed zoom levels:</source>
         <translation>Usar niveles de zoom fijos:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2506"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2527"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2986"/>
         <source>Load defaults</source>
         <translation>Cargar opciones por defecto</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2574"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2595"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2987"/>
         <source>Scaling quality</source>
         <translation>Calidad de escala</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2601"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2622"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2991"/>
         <source>Scaling filter:</source>
         <translation>Filtro de escala:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2633"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2654"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2992"/>
         <source>Nearest neighbor</source>
         <translation>Más cercano</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2638"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2659"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2993"/>
         <source>Bilinear</source>
         <translation>Bilinear</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2680"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2701"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2999"/>
         <source>When unchecked, nearest neighbor algorithm will be used for upscaling.</source>
         <translation>Cuando no está marcado, se utilizará el algoritmo del vecino más cercano para la ampliación.</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2683"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2704"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3001"/>
         <source>Smooth upscaling</source>
         <translation>Suavizar ampliacion</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2702"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2723"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3002"/>
         <source>Smooth animated images</source>
         <translation>Suavizar imágenes animadas</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2781"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2802"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3003"/>
         <source>Theme</source>
         <translation>Tema</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2840"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2861"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3004"/>
         <source>Load preset:</source>
         <translation>Cargar preajuste:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2853"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2857"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2874"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2878"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3005"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3010"/>
         <source>Black</source>
         <translation>Negro</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2862"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2883"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3006"/>
         <source>Dark</source>
         <translation>Oscuro</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2867"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2888"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3007"/>
         <source>Dark Blue</source>
         <translation>Azul oscuro</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2872"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2893"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3008"/>
         <source>Light</source>
         <translation>Ligero</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2896"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2917"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3011"/>
         <source>Use system colors</source>
         <translation>Usar colores del sistema</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2906"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2927"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3012"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;modify&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;modificar&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3132"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3153"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3015"/>
         <source>Accent</source>
         <translation>Primer plano</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3139"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3160"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3016"/>
         <source>Background</source>
         <translation>Fondo</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3146"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3167"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3017"/>
         <source>Background (fullscreen mode)</source>
         <translation>Fondo (modo de pantalla completa)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3184"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3205"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3019"/>
         <source>Text</source>
         <translation>Texto</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3191"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3212"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3020"/>
         <source>Icons</source>
         <translation>Iconos</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3291"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3312"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3024"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="62"/>
         <source>Overlay background</source>
         <translation>Fondo superpuesto</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3329"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3350"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3026"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="60"/>
         <source>Widget background</source>
         <translation>Fondo de widgets</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3336"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3357"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3027"/>
         <source>Folder view top panel</source>
         <translation>Panel superior de vista de carpetas</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3343"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3364"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3028"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="61"/>
         <source>Widget border</source>
         <translation>Borde del widget</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3412"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3433"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3031"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="63"/>
         <source>Overlay text</source>
         <translation>Texto superpuesto</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3450"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3471"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3033"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="64"/>
         <source>Scrollbars</source>
         <translation>Barras de desplazamiento</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3457"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3478"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3034"/>
         <source>Folder view background</source>
         <translation>Fondo de vista de carpeta</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3528"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3549"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3035"/>
         <source>Other window tweaks</source>
         <translation>Otros ajustes de ventana</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3543"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3564"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3036"/>
         <source>Window opacity:</source>
         <translation>Opacidad de la ventana:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3596"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3617"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3037"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3621"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3642"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3038"/>
         <source>Background blur (KDE)</source>
         <translation>Fondo borroso (KDE)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3673"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3694"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3039"/>
         <source>Controls</source>
         <translation>Controles</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3734"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4073"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3755"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4200"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3040"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3063"/>
         <source>Add</source>
         <translation>Agregar</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3741"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4080"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3762"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4207"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3041"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3064"/>
         <source>Edit</source>
         <translation>Editar</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3754"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4087"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3775"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4214"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3042"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3065"/>
         <source>Remove</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3783"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3804"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3043"/>
         <source>Reset to defaults</source>
         <translation type="unfinished">Restablecer valores predeterminados</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3817"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3838"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3045"/>
         <source>Action</source>
         <translation>Acción</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3822"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3843"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3047"/>
         <source>Shortcut</source>
         <translation>Atajo</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3874"/>
-        <source>Mouse &amp; touchpad</source>
-        <translation>Ratón y panel táctil</translation>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3898"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3048"/>
+        <source>Switch image by clicking window edges</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3895"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3905"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3049"/>
+        <source>Visible edges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4984"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3113"/>
+        <source>Apply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4991"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3114"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
+    </message>
+    <message>
+        <source>Mouse &amp; touchpad</source>
+        <translation type="vanished">Ratón y panel táctil</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3935"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3050"/>
         <source>Scroll image with:</source>
         <translation type="unfinished">Desplazar la imagen con:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3903"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3943"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3051"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3908"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3948"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3052"/>
         <source>Touchpad</source>
         <translation>Panel táctil</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3913"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3953"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3053"/>
         <source>Touchpad &amp; Mouse Wheel</source>
         <translation>Panel táctil y rueda del ratón</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3939"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3979"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3055"/>
         <source>Note: you can also zoom by holding RMB and moving the mouse</source>
         <translation>Nota: también puedes hacer zoom manteniendo presionado el botón derecho y moviendo el ratón</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3953"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4007"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3056"/>
+        <source>Mouse scrolling speed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4051"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3057"/>
+        <source>[x]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4080"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3058"/>
         <source>Trackpad detection</source>
         <translation>Detección de panel táctil</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3963"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4090"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3059"/>
         <source>Disable if you have issues with mouse scrolling</source>
         <translation>Desactívelo si tiene problemas con el desplazamiento del ratón</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3995"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4122"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3060"/>
         <source>Scripts</source>
         <translation>Scripts</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4051"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4178"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3061"/>
         <source>Note: these will appear in &quot;Open with&quot; menu.</source>
         <translation>Nota: aparecerán en el menú &quot;Abrir con&quot;.</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4061"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4188"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3062"/>
         <source>Also, you can assign shortcuts to scripts (in &quot;Controls&quot; section).</source>
         <translation>Además, puede asignar accesos directos a los scripts (en la sección &quot;Controles&quot;).</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4170"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4297"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3066"/>
         <source>Advanced</source>
         <translation>Avanzado</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4227"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4354"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3068"/>
         <source>Preload the next/previous image. Results in a much faster image switching (at the expense of wasting more RAM).</source>
         <translation>Precarga la imagen siguiente/anterior. Provoca un cambio de imagen mucho más rápido (a expensas de desperdiciar más RAM).</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4230"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4357"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3070"/>
         <source>Use preloader (recommended)</source>
         <translation>Usar precargador (recomendado)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4240"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4367"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3071"/>
         <source>Load adjacent images in background</source>
         <translation>Cargar imágenes adyacentes en segundo plano</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4268"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4395"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3072"/>
         <source>Thumbnailer thread count:</source>
         <translation>Número de hilos del generador de miniaturas:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4306"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4433"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3073"/>
         <source>2</source>
         <translation>2</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4337"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4464"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3077"/>
         <source>Use thumbnail cache (recommended)</source>
         <translation>Usar caché de miniaturas (recomendado)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4344"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4471"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3078"/>
         <source>Unload off-screen thumbnails</source>
         <translation>Descargar miniaturas fuera de pantalla</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4354"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4481"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3079"/>
         <source>Dynamically unload items to save memory</source>
         <translation>Descargue elementos dinámicamente para ahorrar memoria</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4368"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4495"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3080"/>
         <source>Show save overlay when editing images</source>
         <translation>Mostrar superposición de guardado al editar imágenes</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4383"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4510"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3081"/>
         <source>JPEG save quality:</source>
         <translation>Calidad de guardado JPEG:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4427"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4554"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3082"/>
         <source>q</source>
         <translation>q</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4456"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4583"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3083"/>
         <source>Confirm moving to trash</source>
         <translation>Confirmar mover a la papelera</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4468"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4595"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3084"/>
         <source>Confirm file delete (!)</source>
         <translation>Confirmar eliminación del archivo (!)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4482"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4609"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3085"/>
         <source>JXL animation support (experimental)</source>
         <translation>Soporte de animación JXL (experimental)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4510"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4637"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3086"/>
         <source>Memory allocation limit per image, MB:</source>
         <translation>Límite de asignación de memoria por imagen, MB:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4571"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4698"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3087"/>
         <source>Mpv binary:</source>
         <translation>Ruta del ejecutable mpv:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4612"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4739"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3088"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4706"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4833"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3089"/>
         <source>About qimgv</source>
         <translation>Acerca de qimgv</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4757"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4884"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3090"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -1893,19 +2197,10 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation type="unfinished">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;&lt;html&gt;&lt;head&gt; &lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt; &lt;meta charset=&quot;utf-8&quot; /&gt; &lt;style type=&quot;text/css&quot;&gt; p, li { white-space: pre-wrap; } hr { height: 1px; border-width: 0; } li.unchecked::marker { content: &quot;\2610&quot;; } li.checked::marker { content: &quot;\2612&quot;; } &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Noto Sans&apos;; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt; &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt; &lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:10pt;&quot;&gt;Este es un visor de imágenes sencillo y rápido&lt;/span&gt; &lt;/p&gt; &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt; &lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:10pt;&quot;&gt;Incluye soporte de vídeo a través de libmpv.&lt;/span&gt;&lt;/p&gt; &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt; &lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:10pt; font-weight:600; font-style:italic;&quot;&gt;Proyecto en GitHub:&lt;/span&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:10pt; font-style:italic;&quot;&gt; &lt;/span&gt;&lt;a href=&quot;https://github.com/easymodo/qimgv&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:10pt; font-style:italic; text-decoration: underline; color:#007af4;&quot;&gt;https://github.com/easymodo/qimgv&lt;/span&gt;&lt;/a&gt; &lt;/p&gt; &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt; &lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:10pt; font-weight:600; font-style:italic;&quot;&gt;Desarrollado por:&lt;/span&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:10pt; font-style:italic;&quot;&gt; easymodo (easymodofrf@gmail.com)&lt;/span&gt;&lt;/p&gt; &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt; &lt;a href=&quot;https://github.com/easymodo/qimgv/graphs/contributors&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:10pt; font-weight:600; font-style:italic; text-decoration: underline; color:#007af4;&quot;&gt;Contributors&lt;/span&gt;&lt;/a&gt; &lt;/p&gt; &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;MS Shell Dlg 2&apos;; font-size:10pt; font-weight:600; font-style:italic; text-decoration: underline; color:#007af4;&quot;&gt; &lt;br /&gt;&lt;/p&gt; &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt; &lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:10pt;&quot;&gt;Compilaciones con OpenCV habilitado a trav&amp;eacute;s de &lt;/span&gt;&lt;a href=&quot;https://github.com/dbzhang800/QtOpenCV&quot;&gt;&lt;span style=&quot; font-family:&apos;Ubuntu&apos;; font-size:10pt; text-decoration: underline; color:#007af4;&quot;&gt;QtOpenCV&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:10pt;&quot;&gt; by dbzhang800&lt;/span&gt;&lt;/p&gt; &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;MS Shell Dlg 2&apos;; font-size:10pt; font-weight:600; font-style:italic; text-decoration: underline; color:#007af4;&quot;&gt; &lt;br /&gt;&lt;/p&gt; &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt; &lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:10pt;&quot;&gt;qimgv est&amp;aacute; licenciado bajo &lt;/span&gt;&lt;a href=&quot;https://www.gnu.org/licenses/gpl-3.0.en.html&quot;&gt;&lt;span style=&quot; font-family:&apos;Droid Sans&apos;; font-size:10pt; text-decoration: underline; color:#007af4;&quot;&gt;GNU GPL Versi&amp;oacute;n 3&lt;/span&gt;&lt;/a&gt;&lt;/p&gt; &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;MS Shell Dlg 2&apos;; font-size:10pt;&quot;&gt; &lt;br /&gt;&lt;/p&gt; &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt; &lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:10pt;&quot;&gt;Informar cualquier problema o solicitar funciones &lt;/span&gt;&lt;a href=&quot;https://github.com/easymodo/qimgv/issues&quot;&gt;&lt;span style=&quot; font-family:&apos;Droid Sans&apos;; font-size:10pt; text-decoration: underline; color:#007af4;&quot;&gt;aqu&amp;iacute;&lt;/span&gt;&lt;/a&gt; &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4850"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4977"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3112"/>
         <source>OK</source>
         <translation>OK</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4857"/>
-        <source>Apply</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4864"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="9"/>
@@ -1943,40 +2238,50 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.cpp" line="569"/>
+        <location filename="../../gui/dialogs/settingsdialog.cpp" line="590"/>
         <source>Edit shortcut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.cpp" line="620"/>
+        <location filename="../../gui/dialogs/settingsdialog.cpp" line="641"/>
         <source>Navigate to mpv binary</source>
         <translation>Ubicar el ejecutable mpv</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.cpp" line="649"/>
+        <source>Maximum</source>
+        <translation>Máximo</translation>
     </message>
 </context>
 <context>
     <name>ShortcutCreatorDialog</name>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="14"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="148"/>
         <source>New shortcut</source>
         <translation>Nuevo atajo</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="34"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="149"/>
         <source>Action:</source>
         <translation>Acción:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="73"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="150"/>
         <source>Script:</source>
         <translation>Script:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="117"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="151"/>
         <source>Shortcut:</source>
         <translation>Atajo de teclado:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="124"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="152"/>
         <source>[Enter shortcut]</source>
         <translation>[Introducir atajo]</translation>
     </message>
@@ -1984,32 +2289,32 @@ li.checked::marker { content: &quot;\2612&quot;; }
 <context>
     <name>main</name>
     <message>
-        <location filename="../../main.cpp" line="133"/>
+        <location filename="../../main.cpp" line="126"/>
         <source>File or directory path.</source>
         <translation>Ruta del archivo o carpeta.</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="136"/>
+        <location filename="../../main.cpp" line="129"/>
         <source>Generate all thumbnails for directory.</source>
         <translation>Generar todas las miniaturas de la carpeta.</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="137"/>
+        <location filename="../../main.cpp" line="130"/>
         <source>directory-path</source>
         <translation>ruta-de-la-carpeta</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="139"/>
+        <location filename="../../main.cpp" line="132"/>
         <source>Thumbnail size. Current size is used if not specified.</source>
         <translation>Tamaño de las miniaturas. Si no se especifica se utilizara el tamaño original.</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="140"/>
+        <location filename="../../main.cpp" line="133"/>
         <source>thumbnail-size</source>
         <translation>tamaño-de-miniatura</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="142"/>
+        <location filename="../../main.cpp" line="135"/>
         <source>Show build options.</source>
         <translation>Opciones de visualización.</translation>
     </message>

--- a/qimgv/res/translations/fr_FR.ts
+++ b/qimgv/res/translations/fr_FR.ts
@@ -5,11 +5,13 @@
     <name>ChangelogWindow</name>
     <message>
         <location filename="../../gui/overlays/changelogwindow.ui" line="154"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_changelogwindow.h" line="137"/>
         <source>Close, never show changelogs</source>
         <translation>Fermer, ne jamais afficher les changelogs</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/changelogwindow.ui" line="170"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_changelogwindow.h" line="138"/>
         <source>Close</source>
         <translation>Fermer</translation>
     </message>
@@ -17,62 +19,63 @@
 <context>
     <name>ContextMenu</name>
     <message>
-        <location filename="../../gui/contextmenu.ui" line="229"/>
+        <location filename="../../gui/contextmenu.ui" line="236"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_contextmenu.h" line="449"/>
         <source>Edit</source>
         <translation>Modifier</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="55"/>
+        <location filename="../../gui/contextmenu.cpp" line="58"/>
         <source>Print</source>
         <translation>Imprimer</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="59"/>
+        <location filename="../../gui/contextmenu.cpp" line="62"/>
         <source>Quick copy</source>
         <translation>Copie rapide</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="63"/>
+        <location filename="../../gui/contextmenu.cpp" line="66"/>
         <source>Quick move</source>
         <translation>Déplacement rapide</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="67"/>
+        <location filename="../../gui/contextmenu.cpp" line="70"/>
         <source>Move to trash</source>
         <translation>Déplacer vers la corbeille</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="72"/>
+        <location filename="../../gui/contextmenu.cpp" line="75"/>
         <source>Open</source>
         <translation>Ouvrir</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="77"/>
+        <location filename="../../gui/contextmenu.cpp" line="80"/>
         <source>Folder View</source>
         <translation>Vue dossier</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="82"/>
+        <location filename="../../gui/contextmenu.cpp" line="85"/>
         <source>Settings</source>
         <translation>Paramètres</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="85"/>
+        <location filename="../../gui/contextmenu.cpp" line="88"/>
         <source>Open with...</source>
         <translation>Ouvrir avec...</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="91"/>
+        <location filename="../../gui/contextmenu.cpp" line="94"/>
         <source>Show in folder</source>
         <translation>Afficher dans le dossier</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="99"/>
+        <location filename="../../gui/contextmenu.cpp" line="102"/>
         <source>Back</source>
         <translation>Retour</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="102"/>
+        <location filename="../../gui/contextmenu.cpp" line="105"/>
         <source>Configure menu</source>
         <translation>Menu de configuration</translation>
     </message>
@@ -94,228 +97,228 @@
 <context>
     <name>Core</name>
     <message>
-        <location filename="../../core.cpp" line="255"/>
+        <location filename="../../core.cpp" line="258"/>
         <source>Updated: </source>
         <translation>Mise à jour : </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="261"/>
+        <location filename="../../core.cpp" line="264"/>
         <source>Welcome to </source>
         <translation>Bienvenue dans </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="261"/>
+        <location filename="../../core.cpp" line="264"/>
         <source> version </source>
         <translation> version </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="268"/>
+        <location filename="../../core.cpp" line="271"/>
         <source>Shuffle mode: OFF</source>
         <translation>Mode aléatoire : OFF</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="271"/>
+        <location filename="../../core.cpp" line="274"/>
         <source>Shuffle mode: ON</source>
         <translation>Mode aléatoire : ON</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="280"/>
+        <location filename="../../core.cpp" line="283"/>
         <source>Slideshow: OFF</source>
         <translation>Diaporama : OFF</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="284"/>
+        <location filename="../../core.cpp" line="287"/>
         <source>Slideshow: ON</source>
         <translation>Diaporama : ON</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="355"/>
+        <location filename="../../core.cpp" line="358"/>
         <source>Delete </source>
         <translation>Effacer </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="355"/>
+        <location filename="../../core.cpp" line="358"/>
         <source> items permanently?</source>
         <translation> les éléments de façon définitive ?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="357"/>
+        <location filename="../../core.cpp" line="360"/>
         <source>Delete item permanently?</source>
         <translation>Supprimer définitivement l&apos;élément ?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="358"/>
+        <location filename="../../core.cpp" line="361"/>
         <source>Delete permanently</source>
         <translation>Supprimer définitivement</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="374"/>
+        <location filename="../../core.cpp" line="377"/>
         <source>File removed</source>
         <translation>Élément supprimé</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="378"/>
+        <location filename="../../core.cpp" line="381"/>
         <source>Removed: </source>
         <translation>Supprimé : </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="378"/>
-        <location filename="../../core.cpp" line="408"/>
+        <location filename="../../core.cpp" line="381"/>
+        <location filename="../../core.cpp" line="411"/>
         <source> files</source>
         <translation> fichiers</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="389"/>
+        <location filename="../../core.cpp" line="392"/>
         <source>Move </source>
         <translation>Déplacer </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="389"/>
+        <location filename="../../core.cpp" line="392"/>
         <source> items to trash?</source>
         <translation> éléments vers la corbeille ?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="391"/>
+        <location filename="../../core.cpp" line="394"/>
         <source>Move item to trash?</source>
         <translation>Déplacer l&apos;élément vers la corbeille ?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="392"/>
+        <location filename="../../core.cpp" line="395"/>
         <source>Move to trash</source>
         <translation>Déplacer vers la corbeille</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="404"/>
+        <location filename="../../core.cpp" line="407"/>
         <source>Moved to trash</source>
         <translation>Déplacé vers la corbeille</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="408"/>
+        <location filename="../../core.cpp" line="411"/>
         <source>Moved to trash: </source>
         <translation>Déplacé(s) vers la corbeille : </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="463"/>
+        <location filename="../../core.cpp" line="466"/>
         <source>File copied</source>
         <translation>Fichier copié</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="470"/>
+        <location filename="../../core.cpp" line="473"/>
         <source>Path copied</source>
         <translation>Chemin copié</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="644"/>
-        <location filename="../../core.cpp" line="918"/>
-        <location filename="../../core.cpp" line="939"/>
+        <location filename="../../core.cpp" line="647"/>
+        <location filename="../../core.cpp" line="928"/>
+        <location filename="../../core.cpp" line="949"/>
         <source>File exists</source>
         <translation>Le fichier existe</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="644"/>
+        <location filename="../../core.cpp" line="647"/>
         <source>Overwrite file?</source>
         <translation>Écraser le fichier ?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="812"/>
-        <location filename="../../core.cpp" line="880"/>
+        <location filename="../../core.cpp" line="822"/>
+        <location filename="../../core.cpp" line="890"/>
         <source>Could not create directory </source>
         <translation>Impossible de créer le répertoire </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="916"/>
+        <location filename="../../core.cpp" line="926"/>
         <source>File moved.</source>
         <translation>Fichier déplacé.</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="918"/>
-        <location filename="../../core.cpp" line="939"/>
+        <location filename="../../core.cpp" line="928"/>
+        <location filename="../../core.cpp" line="949"/>
         <source>Destination file exists. Overwrite?</source>
         <translation>Le fichier de destination existe déjà. L&apos;écraser ?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="937"/>
+        <location filename="../../core.cpp" line="947"/>
         <source>File copied.</source>
         <translation>Fichier copié.</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="984"/>
+        <location filename="../../core.cpp" line="994"/>
         <source>Perform action &quot;</source>
         <translation>Exécuter action &quot;</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="984"/>
+        <location filename="../../core.cpp" line="994"/>
         <source>Changes will be saved immediately.</source>
         <translation>Les modifications seront immédiatement enregistrées.</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1002"/>
+        <location filename="../../core.cpp" line="1012"/>
         <source>Flip horizontal</source>
         <translation>Renversement horizontal</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1006"/>
+        <location filename="../../core.cpp" line="1016"/>
         <source>Flip vertical</source>
         <translation>Renversement vertical</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1010"/>
+        <location filename="../../core.cpp" line="1020"/>
         <source>Rotate</source>
         <translation>Tourner</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1014"/>
+        <location filename="../../core.cpp" line="1024"/>
         <source>Resize</source>
         <translation>Redimensionner</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1020"/>
-        <location filename="../../core.cpp" line="1026"/>
+        <location filename="../../core.cpp" line="1030"/>
+        <location filename="../../core.cpp" line="1036"/>
         <source>Crop</source>
         <translation>Recadrer</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1058"/>
+        <location filename="../../core.cpp" line="1068"/>
         <source>File saved</source>
         <translation>Fichier enregistré</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1061"/>
+        <location filename="../../core.cpp" line="1071"/>
         <source>Could not save file</source>
         <translation>Impossible d&apos;enregistrer le fichier</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1171"/>
+        <location filename="../../core.cpp" line="1181"/>
         <source>Could not open image</source>
         <translation>Impossible d&apos;ouvrir l&apos;image</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1175"/>
+        <location filename="../../core.cpp" line="1185"/>
         <source>Can only print static images</source>
         <translation>Ne peut imprimer que des images statiques</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1226"/>
+        <location filename="../../core.cpp" line="1236"/>
         <source>Could not open path: </source>
         <translation>Impossible d&apos;ouvrir le chemin : </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1260"/>
+        <location filename="../../core.cpp" line="1270"/>
         <source>Could not load folder: </source>
         <translation>Impossible de charger le dossier : </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1413"/>
+        <location filename="../../core.cpp" line="1423"/>
         <source>End of directory.</source>
         <translation>Fin du répertoire.</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1452"/>
+        <location filename="../../core.cpp" line="1462"/>
         <source>Load failed: </source>
         <translation>Échec du chargement : </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1496"/>
+        <location filename="../../core.cpp" line="1506"/>
         <source>Error: could not load image.</source>
         <translation>Erreur : impossible de charger l&apos;image.</translation>
     </message>
@@ -324,76 +327,91 @@
     <name>CropPanel</name>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="107"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="370"/>
         <source>Selection</source>
         <translation>Sélection</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="125"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="371"/>
         <source>Width</source>
         <translation>Largeur</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="161"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="372"/>
         <source>Height</source>
         <translation>Hauteur</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="322"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="374"/>
         <source>Aspect Ratio</source>
         <translation>Ratio d&apos;aspect</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="336"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="375"/>
         <source>Free</source>
         <translation>Libre</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="341"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="376"/>
         <source>Custom</source>
         <translation>Personnalisé</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="346"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="377"/>
         <source>Current Image</source>
         <translation>Image actuelle</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="351"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="378"/>
         <source>This Screen</source>
         <translation>Cet écran</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="356"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="379"/>
         <source>1:1</source>
         <translation>1:1</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="361"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="380"/>
         <source>4:3</source>
         <translation>4:3</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="366"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="381"/>
         <source>16:9</source>
         <translation>16:9</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="371"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="382"/>
         <source>16:10</source>
         <translation>16:10</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="499"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="385"/>
         <source>Crop</source>
         <translation>Recadrer</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="512"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="386"/>
         <source>Crop &amp;&amp; Save</source>
         <translation>Recadrer &amp;&amp; Enregistrer</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="527"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="387"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
@@ -402,11 +420,13 @@
     <name>FVOptionsPopup</name>
     <message>
         <location filename="../../gui/folderview/fvoptionspopup.ui" line="32"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_fvoptionspopup.h" line="86"/>
         <source>Form</source>
         <translation>Formulaire</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/fvoptionspopup.ui" line="53"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_fvoptionspopup.h" line="87"/>
         <source>View options</source>
         <translation>Afficher les options</translation>
     </message>
@@ -415,56 +435,67 @@
     <name>FileReplaceDialog</name>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="14"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="130"/>
         <source>Dialog</source>
         <translation>Boîte de dialogue</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="20"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="131"/>
         <source>title</source>
         <translation>Titre</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="33"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="132"/>
         <source>Source:</source>
         <translation>Source :</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="40"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="133"/>
         <source>src</source>
         <translation>src</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="50"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="134"/>
         <source>&gt;&gt;&gt;</source>
         <translation>&gt;&gt;&gt;</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="63"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="135"/>
         <source>Destination:</source>
         <translation>Destination :</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="70"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="136"/>
         <source>dst</source>
         <translation>dst</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="111"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="137"/>
         <source>Apply to all</source>
         <translation>Appliquer à tout</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="118"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="138"/>
         <source>Yes</source>
         <translation>Oui</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="125"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="139"/>
         <source>No</source>
         <translation>Non</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="132"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="140"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
@@ -473,77 +504,93 @@
     <name>FolderView</name>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="17"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="410"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="145"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="411"/>
         <source>[path]</source>
         <translation>[path]</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="195"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="413"/>
         <source>FolderViewSlider</source>
         <translation>FolderViewSlider</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="242"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="416"/>
         <source>CheckableButton</source>
         <translation>CheckableButto</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="274"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="426"/>
         <source>PanelComboBox</source>
         <translation>PanelComboBox</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="281"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="418"/>
         <source>A - Z</source>
         <translation>A &gt; Z</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="286"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="419"/>
         <source>Z - A</source>
         <translation>Z &gt; A</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="291"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="420"/>
         <source>Size</source>
         <translation>Taille</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="296"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="421"/>
         <source>Size (desc)</source>
         <translation>Taille (descendante)</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="301"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="422"/>
         <source>Oldest</source>
         <translation>Plus ancien</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="306"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="423"/>
         <source>Newest</source>
         <translation>Plus récent</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="348"/>
         <location filename="../../gui/folderview/folderview.ui" line="373"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="429"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="432"/>
         <source>PanelButton</source>
         <translation>PanelButton</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="414"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="435"/>
         <source>PanelButtonRE</source>
         <translation>PanelButtonRE</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="476"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="438"/>
         <source>PlacesPanel</source>
         <translation>PlacesPanel</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="532"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="440"/>
         <source>BOOKMARKS</source>
         <translation>BOOKMARKS</translation>
     </message>
@@ -551,11 +598,15 @@
         <location filename="../../gui/folderview/folderview.ui" line="551"/>
         <location filename="../../gui/folderview/folderview.ui" line="638"/>
         <location filename="../../gui/folderview/folderview.ui" line="657"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="442"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="446"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="449"/>
         <source>PlacesPanelButton</source>
         <translation>PlacesPanelButton</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="611"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="444"/>
         <source>FILESYSTEM</source>
         <translation>FILESYSTEM</translation>
     </message>
@@ -564,11 +615,13 @@
     <name>ImageInfoOverlay</name>
     <message>
         <location filename="../../gui/overlays/imageinfooverlay.ui" line="65"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_imageinfooverlay.h" line="111"/>
         <source>OverlayHeaderWidget</source>
         <translation>OverlayHeaderWidget</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/imageinfooverlay.ui" line="99"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_imageinfooverlay.h" line="113"/>
         <source>EXIF Tags</source>
         <translation>EXIF Tags</translation>
     </message>
@@ -584,35 +637,35 @@
 <context>
     <name>MW</name>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="565"/>
+        <location filename="../../gui/mainwindow.cpp" line="581"/>
         <source>Save File as...</source>
         <translation>Enregistrer le fichier sous...</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="800"/>
+        <location filename="../../gui/mainwindow.cpp" line="816"/>
         <source>Folder view</source>
         <translation>Affichage dossier</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="801"/>
-        <location filename="../../gui/mainwindow.cpp" line="802"/>
-        <location filename="../../gui/mainwindow.cpp" line="805"/>
-        <location filename="../../gui/mainwindow.cpp" line="806"/>
+        <location filename="../../gui/mainwindow.cpp" line="817"/>
+        <location filename="../../gui/mainwindow.cpp" line="818"/>
+        <location filename="../../gui/mainwindow.cpp" line="821"/>
+        <location filename="../../gui/mainwindow.cpp" line="822"/>
         <source>No file opened.</source>
         <translation>Aucun fichier ouvert.</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="867"/>
+        <location filename="../../gui/mainwindow.cpp" line="883"/>
         <source>Fit Window</source>
         <translation>Ajuster fenêtre</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="871"/>
+        <location filename="../../gui/mainwindow.cpp" line="887"/>
         <source>Fit Width</source>
         <translation>Ajuster largeur</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="875"/>
+        <location filename="../../gui/mainwindow.cpp" line="891"/>
         <source>Fit 1:1</source>
         <translation>Ajuster 1:1</translation>
     </message>
@@ -621,71 +674,85 @@
     <name>PrintDialog</name>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="20"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="304"/>
         <source>Print image</source>
         <translation>Imprimer l&apos;image</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="126"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="306"/>
         <source>Preview</source>
         <translation>Aperçu</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="179"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="307"/>
         <source>Printer:</source>
         <translation>Imprimante :</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="189"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="308"/>
         <source>&lt;No printers found&gt;</source>
         <translation>&lt;No printers found&gt;</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="271"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="309"/>
         <source>Page orientation:</source>
         <translation>Orientation de la page :</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="297"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="310"/>
         <source>Portrait</source>
         <translation>Portrait</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="307"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="311"/>
         <source>Landscape</source>
         <translation>Paysage</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="348"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="312"/>
         <source>Color mode:</source>
         <translation>Mode couleur :</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="374"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="313"/>
         <source>Grayscale</source>
         <translation>Niveaux de gris</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="384"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="314"/>
         <source>Color</source>
         <translation>Couleur</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="409"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="315"/>
         <source>Fit to page</source>
         <translation>Ajuster à la page</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="434"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="316"/>
         <source>Export PDF</source>
         <translation>Exporter en PDF</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="454"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="317"/>
         <source>Print</source>
         <translation>Imprimer</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="464"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="318"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
@@ -825,11 +892,14 @@
     <message>
         <location filename="../../gui/overlays/renameoverlay.ui" line="171"/>
         <location filename="../../gui/overlays/renameoverlay.ui" line="260"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_renameoverlay.h" line="213"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_renameoverlay.h" line="214"/>
         <source>Rename</source>
         <translation>Renommer</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/renameoverlay.ui" line="273"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_renameoverlay.h" line="215"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
@@ -838,151 +908,181 @@
     <name>ResizeDialog</name>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="32"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="358"/>
         <source>Resize</source>
         <translation>Redimensionner</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="63"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="359"/>
         <source>By Percent:</source>
         <translation>Par pourcentage :</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="79"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="360"/>
         <source>By Absolute Size:</source>
         <translation>Selon taille absolue :</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="98"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="361"/>
         <source>Percent:</source>
         <translation>Pourcentage :</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="119"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="362"/>
         <source>Width:</source>
         <translation>Largeur :</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="205"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="363"/>
         <source>Height:</source>
         <translation>Hauteur :</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="275"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="364"/>
         <source>Keep aspect ratio</source>
         <translation>Conserver le ratio d&apos;aspect</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="304"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="365"/>
         <source>Filter:</source>
         <translation>Filtre :</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="330"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="366"/>
         <source>Nearest</source>
         <translation>Plus proche</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="335"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="367"/>
         <source>Bilinear</source>
         <translation>Bilinéaire</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="340"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="368"/>
         <source>Bicubic</source>
         <translation>Bicubique</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="345"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="369"/>
         <source>Lanczos3</source>
         <translation>Lanczos3</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="358"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="371"/>
         <source>Common sizes:</source>
         <translation>Dimensions courantes :</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="392"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="372"/>
         <source>Select:</source>
         <translation>Sélectionnez :</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="397"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="373"/>
         <source>1366 x 768</source>
         <translation>1366 x 768</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="402"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="374"/>
         <source>1440 x 900</source>
         <translation>1440 x 900</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="407"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="375"/>
         <source>1440 x 1050</source>
         <translation>1440 x 1050</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="412"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="376"/>
         <source>1600 x 1200</source>
         <translation>1600 x 1200</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="417"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="377"/>
         <source>1920 x 1080 (FullHD)</source>
         <translation>1920 x 1080 (FullHD)</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="422"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="378"/>
         <source>1920 x 1200 (FullHD)</source>
         <translation>1920 x 1200 (FullHD)</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="427"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="379"/>
         <source>2560 x 1080</source>
         <translation>2560 x 1080</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="432"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="380"/>
         <source>2560 x 1440</source>
         <translation>2560 x 1440</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="437"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="381"/>
         <source>2560 x 1600</source>
         <translation>2560 x 1600</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="442"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="382"/>
         <source>3840 x 1600 (UW 4K)</source>
         <translation>3840 x 1600 (UW 4K)</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="447"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="383"/>
         <source>3840 x 2160 (UHD-1)</source>
         <translation>3840 x 2160 (UHD-1)</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="470"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="385"/>
         <source>Fit to desktop</source>
         <translation>Adapter au bureau</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="489"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="386"/>
         <source>Fill desktop (expanding)</source>
         <translation>« Remplir » le bureau (expansion)</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="508"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="387"/>
         <source>Reset</source>
         <translation>Réinitialiser</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="575"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="388"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="594"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="389"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
@@ -1034,21 +1134,25 @@
     <name>SaveConfirmOverlay</name>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="81"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="145"/>
         <source>Unsaved edits</source>
         <translation>Modifications non sauvegardées</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="127"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="146"/>
         <source>Save</source>
         <translation>Enregistrer</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="140"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="147"/>
         <source>Save as</source>
         <translation>Enregistrer sous</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="169"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="148"/>
         <source>Discard</source>
         <translation>Rejeter</translation>
     </message>
@@ -1057,31 +1161,37 @@
     <name>ScriptEditorDialog</name>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="48"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="208"/>
         <source>Command:</source>
         <translation>Commande :</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="84"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="209"/>
         <source>NOTE: make sure your .sh script has execute flag.</source>
         <translation>NB: assurez-vous que votre script .sh possède le drapeau execute.</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="91"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="210"/>
         <source>Name:</source>
         <translation>Nom :</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="148"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="212"/>
         <source>Wait to finish</source>
         <translation>Attendre la fin</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="218"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="214"/>
         <source>Create</source>
         <translation>Créer</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="225"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="215"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
@@ -1126,752 +1236,934 @@
     <name>SettingsDialog</name>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="47"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2892"/>
         <source>Preferences</source>
         <translation>Préférences</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="53"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2894"/>
         <source>SettingsDialog</source>
         <translation>Boîte de dialogue des réglages</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="339"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2900"/>
         <source>General</source>
         <translation>Général</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="415"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2901"/>
         <source>Language:</source>
         <translation>Langue :</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="435"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2902"/>
         <source>Requires application restart</source>
         <translation>Nécessite le redémarrage de l&apos;application</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="473"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2903"/>
         <source>Open in fullscreen</source>
         <translation>Ouvrir en plein écran</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="480"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2904"/>
         <source>Start in folder view by default</source>
         <translation>Démarrage en mode dossier par défaut</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="551"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2905"/>
         <source>User interface</source>
         <translation>Interface utilisateur</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="606"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2906"/>
         <source>Image info in window title</source>
         <translation>Informations sur l&apos;image dans le titre de la fenêtre</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="626"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2907"/>
         <source>Auto-hide cursor</source>
         <translation>Masquer automatiquement le curseur</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="633"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2909"/>
         <source>Turn this off if you are using a touchpad with libinput driver.</source>
         <translation>Désactivez cette option si vous utilisez un pavé tactile avec le pilote libinput.</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="636"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2911"/>
         <source>Enable smooth scrolling</source>
         <translation>Activer le défilement « fluide »</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="643"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2912"/>
         <source>Fullscreen info bar</source>
         <translation>Barre d&apos;information plein écran</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="656"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2913"/>
         <source>Status bar</source>
         <translation>Barre d&apos;état</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="689"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2914"/>
         <source>Zoom indicator:</source>
         <translation>Indicateur de zoom :</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="699"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2915"/>
         <source>On</source>
         <translation>On</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="706"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2916"/>
         <source>Off</source>
         <translation>Off</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="713"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2917"/>
         <source>Auto</source>
         <translation>Auto</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="753"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2918"/>
         <source>Automatic window resize</source>
         <translation>Redimensionnement automatique de la fenêtre</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="763"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2919"/>
         <source>Match displayed content</source>
         <translation>Faire correspondre le contenu affiché</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="799"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2920"/>
         <source>Screen area limit for auto resize:</source>
         <translation>Limite de la surface de l&apos;écran pour le redimensionnement automatique :</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="864"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2240"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2261"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2921"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2978"/>
         <source>xx</source>
         <translation>xx</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="962"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2925"/>
         <source>Thumbnail panel</source>
         <translation>Panneau des vignettes</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1018"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2926"/>
         <source>Crop previews</source>
         <translation>Aperçu des recadrages</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1031"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2927"/>
         <source>Pinned</source>
         <translation>Épinglé</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1050"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2928"/>
         <source>Disable in windowed mode</source>
         <translation>Désactivé en mode fenêtre</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1057"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2929"/>
         <source>Center selected image</source>
         <translation>Centrer l&apos;image sélectionnée</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1109"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2930"/>
         <source>Extended</source>
         <translation>Étendu</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1119"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2931"/>
         <source>Previews only</source>
         <translation>Aperçus seulement</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1126"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2932"/>
         <source>Display style:</source>
         <translation>Style d&apos;affichage :</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1139"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2933"/>
         <source>Show filename and resolution</source>
         <translation>Afficher le nom du fichier et la résolution</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1159"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2934"/>
         <source>Simple</source>
         <translation>Simple</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1183"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2935"/>
         <source>Preview size:</source>
         <translation>Taille de l&apos;aperçu :</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1258"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2936"/>
         <source>Position:</source>
         <translation>Position :</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1266"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2064"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2085"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2937"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2972"/>
         <source>Top</source>
         <translation>Haut</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1271"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2938"/>
         <source>Bottom</source>
         <translation>Bas</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1276"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2939"/>
         <source>Left</source>
         <translation>Gauche</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1281"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2940"/>
         <source>Right</source>
         <translation>Droite</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1374"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2942"/>
         <source>Folder navigation</source>
         <translation>Navigation dans les dossiers</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1400"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2943"/>
         <source>Stop</source>
         <translation>Arrêt</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1410"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2944"/>
         <source>Loop folder</source>
         <translation>Dossier en boucle</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1417"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2945"/>
         <source>Go to the next folder</source>
         <translation>Aller au dossier suivant</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1424"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2946"/>
         <source>After reaching the end:</source>
         <translation>Après avoir atteint la fin :</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1476"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2947"/>
         <source>Default sorting mode:</source>
         <translation>Mode de tri par défaut :</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1493"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2948"/>
         <source>A - Z</source>
         <translation>A &gt; Z</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1498"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2949"/>
         <source>Z - A</source>
         <translation>Z &gt; A</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1503"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2950"/>
         <source>Size</source>
         <translation>Taille</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1508"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2951"/>
         <source>Size (desc)</source>
         <translation>Taille (descendante)</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1513"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2952"/>
         <source>Oldest</source>
         <translation>Plus ancien</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1518"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2953"/>
         <source>Newest</source>
         <translation>Plus récent</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1541"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2955"/>
         <source>Apply sorting to folders</source>
         <translation>Appliquer le tri aux dossiers</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1609"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1555"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2956"/>
+        <source>Show hidden files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1623"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2957"/>
         <source>Video playback</source>
         <translation>Lecture vidéo</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1651"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1665"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2958"/>
         <source>Play sounds</source>
         <translation>Jouer les sons</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1720"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1734"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2959"/>
         <source>Slideshow</source>
         <translation>Diaporama</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1740"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1754"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2960"/>
         <source>Switch interval:</source>
         <translation>Intervalle de changement :</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1771"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1785"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2961"/>
         <source>ms</source>
         <translation>millisecondes</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1803"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1817"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2962"/>
         <source>Loop slideshow</source>
         <translation>Diaporama en boucle</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1900"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1914"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2963"/>
         <source>View</source>
         <translation>Affichage</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1956"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1970"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2964"/>
         <source>Display options</source>
         <translation>Options d&apos;affichage</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1980"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1994"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2965"/>
         <source>Image fit:</source>
         <translation>Ajustement de l&apos;image :</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1987"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2001"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2966"/>
         <source>Fit in window</source>
         <translation>Ajustement à la fenêtre</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1997"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2011"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2967"/>
         <source>Stretch to width</source>
         <translation>Étirer en largeur</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2004"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2018"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2968"/>
         <source>1:1</source>
         <translation>1:1</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="2025"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2969"/>
         <source>Fit in window (stretch)</source>
         <translation>Ajuster à la fenêtre (étirer)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2026"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2047"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2970"/>
         <source>Keep fit mode when switching images</source>
         <translation>Maintenir mode « ajustement » en passant d&apos;une image à l&apos;autre</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2057"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2078"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2971"/>
         <source>Focus in 1:1 mode:</source>
         <translation>Mise au point en mode 1:1 :</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2071"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2092"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2973"/>
         <source>Center</source>
         <translation>Centrer</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2078"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2099"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2974"/>
         <source>At cursor</source>
         <translation>Au curseur</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2103"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2124"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2975"/>
         <source>Part of image that&apos;s focused after switching to 1:1</source>
         <translation>Partie de l&apos;image mise au point après le passage au format 1:1</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2126"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2147"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2976"/>
         <source>Grid background on images with transparency</source>
         <translation>Fond quadrillé sur les images en transparence</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2163"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2184"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2977"/>
         <source>Expand images, up to:</source>
         <translation>Agrandir les images jusqu&apos;à :</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2271"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2292"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2979"/>
         <source>Images smaller than window will be zoomed in</source>
         <translation>Les images plus petites que la fenêtre seront agrandies</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2323"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2344"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2980"/>
         <source>Zoom options</source>
         <translation>Options de zoom</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2330"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2351"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2981"/>
         <source>Unlock minimum zoom</source>
         <translation>Déverrouiller le zoom minimum</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2340"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2361"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2982"/>
         <source>Always allow zooming below 100%</source>
         <translation>Toujours autoriser les zooms inférieurs à 100 %</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2365"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2386"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2983"/>
         <source>Zoom step:</source>
         <translation>Niveau de zoom :</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2433"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2454"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2984"/>
         <source>[step]</source>
         <translation>[niveau]</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2462"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2483"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2985"/>
         <source>Use fixed zoom levels:</source>
         <translation>Utiliser des niveaux de zoom fixes :</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2506"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2527"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2986"/>
         <source>Load defaults</source>
         <translation>Charger les valeurs par défaut</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2574"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2595"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2987"/>
         <source>Scaling quality</source>
         <translation>Qualité de mise à l&apos;échelle</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2601"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2622"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2991"/>
         <source>Scaling filter:</source>
         <translation>Filtre de mise à l&apos;échelle :</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2633"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2654"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2992"/>
         <source>Nearest neighbor</source>
         <translation>Plus proche « voisin »</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2638"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2659"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2993"/>
         <source>Bilinear</source>
         <translation>Bilinéaire</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2680"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2701"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2999"/>
         <source>When unchecked, nearest neighbor algorithm will be used for upscaling.</source>
         <translation>Si la case n&apos;est pas cochée, l&apos;algorithme &quot;voisin&quot; le plus proche sera utilisé pour la mise à l&apos;échelle.</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2683"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2704"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3001"/>
         <source>Smooth upscaling</source>
         <translation>Mise à l&apos;échelle « fluide »</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2702"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2723"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3002"/>
         <source>Smooth animated images</source>
         <translation>Images animées « fluides »</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2781"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2802"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3003"/>
         <source>Theme</source>
         <translation>Thème</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2840"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2861"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3004"/>
         <source>Load preset:</source>
         <translation>Charger le réglage :</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2853"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2857"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2874"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2878"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3005"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3010"/>
         <source>Black</source>
         <translation>Noir</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2862"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2883"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3006"/>
         <source>Dark</source>
         <translation>Sombre</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2867"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2888"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3007"/>
         <source>Dark Blue</source>
         <translation>Bleu sombre</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2872"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2893"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3008"/>
         <source>Light</source>
         <translation>Lumineux</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2896"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2917"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3011"/>
         <source>Use system colors</source>
         <translation>Utiliser les couleurs système</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2906"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2927"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3012"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;modify&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;modify&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3132"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3153"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3015"/>
         <source>Accent</source>
         <translation>Accentuation</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3139"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3160"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3016"/>
         <source>Background</source>
         <translation>Arrière-plan</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3146"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3167"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3017"/>
         <source>Background (fullscreen mode)</source>
         <translation>Arrière-plan (mode plein écran)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3184"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3205"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3019"/>
         <source>Text</source>
         <translation>Texte</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3191"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3212"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3020"/>
         <source>Icons</source>
         <translation>Icones</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3291"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3312"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3024"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="62"/>
         <source>Overlay background</source>
         <translation>Arrière-plan de surimpression</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3329"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3350"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3026"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="60"/>
         <source>Widget background</source>
         <translation>Arrière-plan du widget</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3336"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3357"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3027"/>
         <source>Folder view top panel</source>
         <translation>Vue de dossier panneau supérieur</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3343"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3364"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3028"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="61"/>
         <source>Widget border</source>
         <translation>Bordure de widget</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3412"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3433"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3031"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="63"/>
         <source>Overlay text</source>
         <translation>Texte en surimpression</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3450"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3471"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3033"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="64"/>
         <source>Scrollbars</source>
         <translation>Barres de défilement</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3457"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3478"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3034"/>
         <source>Folder view background</source>
         <translation>Arrière-plan de l&apos;affichage des dossiers</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3528"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3549"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3035"/>
         <source>Other window tweaks</source>
         <translation>Autres réglages de fenêtres</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3543"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3564"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3036"/>
         <source>Window opacity:</source>
         <translation>Opacité de la fenêtre :</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3596"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3617"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3037"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3621"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3642"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3038"/>
         <source>Background blur (KDE)</source>
         <translation>Flou d&apos;arrière-plan (KDE)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3673"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3694"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3039"/>
         <source>Controls</source>
         <translation>Contrôles</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3734"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4073"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3755"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4200"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3040"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3063"/>
         <source>Add</source>
         <translation>Ajouter</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3741"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4080"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3762"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4207"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3041"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3064"/>
         <source>Edit</source>
         <translation>Modifier</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3754"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4087"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3775"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4214"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3042"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3065"/>
         <source>Remove</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3783"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3804"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3043"/>
         <source>Reset to defaults</source>
         <translation>Rétablir les valeurs par défaut</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3817"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3838"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3045"/>
         <source>Action</source>
         <translation>Action</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3822"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3843"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3047"/>
         <source>Shortcut</source>
         <translation>Raccourci</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3874"/>
-        <source>Mouse &amp; touchpad</source>
-        <translation>Souris et pavé tactile</translation>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3898"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3048"/>
+        <source>Switch image by clicking window edges</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3895"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3905"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3049"/>
+        <source>Visible edges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mouse &amp; touchpad</source>
+        <translation type="vanished">Souris et pavé tactile</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3935"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3050"/>
         <source>Scroll image with:</source>
         <translation>Faire défiler l&apos;image avec :</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3903"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3943"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3051"/>
         <source>None</source>
         <translation>Aucun</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3908"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3948"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3052"/>
         <source>Touchpad</source>
         <translation>Pavé tactile</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3913"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3953"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3053"/>
         <source>Touchpad &amp; Mouse Wheel</source>
         <translation>Pavé tactile et molette de souris</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3939"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3979"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3055"/>
         <source>Note: you can also zoom by holding RMB and moving the mouse</source>
         <translation>NB : vous pouvez aussi zoomer en maintenant la touche RMB enfoncée et en déplaçant la souris</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3953"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4007"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3056"/>
+        <source>Mouse scrolling speed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4051"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3057"/>
+        <source>[x]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4080"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3058"/>
         <source>Trackpad detection</source>
         <translation>Détection du pavé tactile</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3963"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4090"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3059"/>
         <source>Disable if you have issues with mouse scrolling</source>
         <translation>Désactiver en cas de problème avec le défilement de la souris</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3995"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4122"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3060"/>
         <source>Scripts</source>
         <translation>Scripts</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4051"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4178"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3061"/>
         <source>Note: these will appear in &quot;Open with&quot; menu.</source>
         <translation>NB :  apparaîtra dans le menu &quot;Ouvrir avec&quot;.</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4061"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4188"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3062"/>
         <source>Also, you can assign shortcuts to scripts (in &quot;Controls&quot; section).</source>
         <translation>Vous pouvez aussi attribuer des raccourcis aux scripts (dans la section &quot;Contrôles&quot;).</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4170"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4297"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3066"/>
         <source>Advanced</source>
         <translation>Avancé</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4227"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4354"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3068"/>
         <source>Preload the next/previous image. Results in a much faster image switching (at the expense of wasting more RAM).</source>
         <translation>Précharger l&apos;image suivante/précédente. Cela permet de changer d&apos;image beaucoup plus rapidement (au prix d&apos;une perte de mémoire vive plus importante).</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4230"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4357"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3070"/>
         <source>Use preloader (recommended)</source>
         <translation>Utiliser préchargement (recommandé)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4240"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4367"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3071"/>
         <source>Load adjacent images in background</source>
         <translation>Chargement d&apos;images « voisines » en arrière-plan</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4268"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4395"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3072"/>
         <source>Thumbnailer thread count:</source>
         <translation>Nombre de rangées de vignettes :</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4306"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4433"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3073"/>
         <source>2</source>
         <translation>2</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4337"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4464"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3077"/>
         <source>Use thumbnail cache (recommended)</source>
         <translation>Utiliser le cache des vignettes (recommandé)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4344"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4471"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3078"/>
         <source>Unload off-screen thumbnails</source>
         <translation>« Décharger » les vignettes hors écran</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4354"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4481"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3079"/>
         <source>Dynamically unload items to save memory</source>
         <translation>« Décharger » dynamiquement les éléments pour économiser de la mémoire</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4368"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4495"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3080"/>
         <source>Show save overlay when editing images</source>
         <translation>Afficher la fenêtre d&apos;enregistrement lors de l&apos;édition d&apos;images</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4383"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4510"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3081"/>
         <source>JPEG save quality:</source>
         <translation>Qualité d&apos;enregistrement JPEG :</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4427"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4554"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3082"/>
         <source>q</source>
         <translation>q</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4456"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4583"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3083"/>
         <source>Confirm moving to trash</source>
         <translation>Confirmer le déplacement vers la corbeille</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4468"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4595"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3084"/>
         <source>Confirm file delete (!)</source>
         <translation>Confirmer la suppression du fichier (!)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4482"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4609"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3085"/>
         <source>JXL animation support (experimental)</source>
         <translation>Prise en charge des animations JXL (expérimental)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4510"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4637"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3086"/>
         <source>Memory allocation limit per image, MB:</source>
         <translation>Limite d&apos;allocation de mémoire par image, en MB :</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4571"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4698"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3087"/>
         <source>Mpv binary:</source>
         <translation>Mpv binaire :</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4612"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4739"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3088"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4706"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4833"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3089"/>
         <source>About qimgv</source>
         <translation>À propos de qimgv</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4757"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4884"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3090"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -1910,17 +2202,20 @@ li.checked::marker { content: &quot;\2612&quot;; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:10pt;&quot;&gt;Report any issues / request features &lt;/span&gt;&lt;a href=&quot;https://github.com/easymodo/qimgv/issues&quot;&gt;&lt;span style=&quot; font-family:&apos;Droid Sans&apos;; font-size:10pt; text-decoration: underline; color:#007af4;&quot;&gt;here&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4850"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4977"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3112"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4857"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4984"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3113"/>
         <source>Apply</source>
         <translation>Appliquer</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4864"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4991"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3114"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
@@ -1960,40 +2255,50 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>Couleur du texte</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.cpp" line="569"/>
+        <location filename="../../gui/dialogs/settingsdialog.cpp" line="590"/>
         <source>Edit shortcut</source>
         <translation>Modifier raccourci</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.cpp" line="620"/>
+        <location filename="../../gui/dialogs/settingsdialog.cpp" line="641"/>
         <source>Navigate to mpv binary</source>
         <translation>Naviguer vers mpv binaire</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.cpp" line="649"/>
+        <source>Maximum</source>
+        <translation>Maximum</translation>
     </message>
 </context>
 <context>
     <name>ShortcutCreatorDialog</name>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="14"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="148"/>
         <source>New shortcut</source>
         <translation>Nouveau raccourci</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="34"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="149"/>
         <source>Action:</source>
         <translation>Action :</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="73"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="150"/>
         <source>Script:</source>
         <translation>Script :</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="117"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="151"/>
         <source>Shortcut:</source>
         <translation>Raccourci :</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="124"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="152"/>
         <source>[Enter shortcut]</source>
         <translation>[Entrer raccourci]</translation>
     </message>
@@ -2001,32 +2306,32 @@ li.checked::marker { content: &quot;\2612&quot;; }
 <context>
     <name>main</name>
     <message>
-        <location filename="../../main.cpp" line="133"/>
+        <location filename="../../main.cpp" line="126"/>
         <source>File or directory path.</source>
         <translation>Chemin d&apos;accès au fichier ou au répertoire.</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="136"/>
+        <location filename="../../main.cpp" line="129"/>
         <source>Generate all thumbnails for directory.</source>
         <translation>Générer toutes les vignettes du répertoire.</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="137"/>
+        <location filename="../../main.cpp" line="130"/>
         <source>directory-path</source>
         <translation>chemin du répertoire</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="139"/>
+        <location filename="../../main.cpp" line="132"/>
         <source>Thumbnail size. Current size is used if not specified.</source>
         <translation>Taille de la vignette. La taille actuelle est utilisée si elle n&apos;est pas spécifiée.</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="140"/>
+        <location filename="../../main.cpp" line="133"/>
         <source>thumbnail-size</source>
         <translation>taille de la vignette</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="142"/>
+        <location filename="../../main.cpp" line="135"/>
         <source>Show build options.</source>
         <translation>Afficher les options de build.</translation>
     </message>

--- a/qimgv/res/translations/ja_JP.ts
+++ b/qimgv/res/translations/ja_JP.ts
@@ -5,11 +5,13 @@
     <name>ChangelogWindow</name>
     <message>
         <location filename="../../gui/overlays/changelogwindow.ui" line="154"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_changelogwindow.h" line="137"/>
         <source>Close, never show changelogs</source>
         <translation>閉じる。今後変更履歴を表示しない</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/changelogwindow.ui" line="170"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_changelogwindow.h" line="138"/>
         <source>Close</source>
         <translation>閉じる</translation>
     </message>
@@ -17,62 +19,63 @@
 <context>
     <name>ContextMenu</name>
     <message>
-        <location filename="../../gui/contextmenu.ui" line="229"/>
+        <location filename="../../gui/contextmenu.ui" line="236"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_contextmenu.h" line="449"/>
         <source>Edit</source>
         <translation>編集</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="55"/>
+        <location filename="../../gui/contextmenu.cpp" line="58"/>
         <source>Print</source>
         <translation>印刷</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="59"/>
+        <location filename="../../gui/contextmenu.cpp" line="62"/>
         <source>Quick copy</source>
         <translation>クイックコピー</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="63"/>
+        <location filename="../../gui/contextmenu.cpp" line="66"/>
         <source>Quick move</source>
         <translation>クイック移動</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="67"/>
+        <location filename="../../gui/contextmenu.cpp" line="70"/>
         <source>Move to trash</source>
         <translation>ゴミ箱へ移動</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="72"/>
+        <location filename="../../gui/contextmenu.cpp" line="75"/>
         <source>Open</source>
         <translation>開く</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="77"/>
+        <location filename="../../gui/contextmenu.cpp" line="80"/>
         <source>Folder View</source>
         <translation>フォルダービュー</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="82"/>
+        <location filename="../../gui/contextmenu.cpp" line="85"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="85"/>
+        <location filename="../../gui/contextmenu.cpp" line="88"/>
         <source>Open with...</source>
         <translation type="unfinished">スクリプト/アプリで開く...</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="91"/>
+        <location filename="../../gui/contextmenu.cpp" line="94"/>
         <source>Show in folder</source>
         <translation type="unfinished">ファイルの場所を開く</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="99"/>
+        <location filename="../../gui/contextmenu.cpp" line="102"/>
         <source>Back</source>
         <translation>戻る</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="102"/>
+        <location filename="../../gui/contextmenu.cpp" line="105"/>
         <source>Configure menu</source>
         <translation type="unfinished">スクリプト/アプリの追加</translation>
     </message>
@@ -94,228 +97,228 @@
 <context>
     <name>Core</name>
     <message>
-        <location filename="../../core.cpp" line="255"/>
+        <location filename="../../core.cpp" line="258"/>
         <source>Updated: </source>
         <translation>更新: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="261"/>
+        <location filename="../../core.cpp" line="264"/>
         <source>Welcome to </source>
         <translation>ようこそ </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="261"/>
+        <location filename="../../core.cpp" line="264"/>
         <source> version </source>
         <translation> バージョン </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="268"/>
+        <location filename="../../core.cpp" line="271"/>
         <source>Shuffle mode: OFF</source>
         <translation>シャッフルモード: OFF</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="271"/>
+        <location filename="../../core.cpp" line="274"/>
         <source>Shuffle mode: ON</source>
         <translation>シャッフルモード: ON</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="280"/>
+        <location filename="../../core.cpp" line="283"/>
         <source>Slideshow: OFF</source>
         <translation>スライドショー: OFF</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="284"/>
+        <location filename="../../core.cpp" line="287"/>
         <source>Slideshow: ON</source>
         <translation>スライドショー: ON</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="355"/>
+        <location filename="../../core.cpp" line="358"/>
         <source>Delete </source>
         <translation> </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="355"/>
+        <location filename="../../core.cpp" line="358"/>
         <source> items permanently?</source>
         <translation>個のアイテムを完全に削除しますか？</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="357"/>
+        <location filename="../../core.cpp" line="360"/>
         <source>Delete item permanently?</source>
         <translation>アイテムを完全に削除しますか？</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="358"/>
+        <location filename="../../core.cpp" line="361"/>
         <source>Delete permanently</source>
         <translation>完全に削除</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="374"/>
+        <location filename="../../core.cpp" line="377"/>
         <source>File removed</source>
         <translation>ファイルを削除しました</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="378"/>
+        <location filename="../../core.cpp" line="381"/>
         <source>Removed: </source>
         <translation>削除済み: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="378"/>
-        <location filename="../../core.cpp" line="408"/>
+        <location filename="../../core.cpp" line="381"/>
+        <location filename="../../core.cpp" line="411"/>
         <source> files</source>
         <translation> 個のファイル</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="389"/>
+        <location filename="../../core.cpp" line="392"/>
         <source>Move </source>
         <translation> </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="389"/>
+        <location filename="../../core.cpp" line="392"/>
         <source> items to trash?</source>
         <translation>個のアイテムをゴミ箱へ移動しますか？</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="391"/>
+        <location filename="../../core.cpp" line="394"/>
         <source>Move item to trash?</source>
         <translation>アイテムをゴミ箱へ移動しますか？</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="392"/>
+        <location filename="../../core.cpp" line="395"/>
         <source>Move to trash</source>
         <translation>ゴミ箱へ移動</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="404"/>
+        <location filename="../../core.cpp" line="407"/>
         <source>Moved to trash</source>
         <translation>ゴミ箱に移動しました</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="408"/>
+        <location filename="../../core.cpp" line="411"/>
         <source>Moved to trash: </source>
         <translation>ゴミ箱に移動しました: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="463"/>
+        <location filename="../../core.cpp" line="466"/>
         <source>File copied</source>
         <translation>ファイルがコピーされました</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="470"/>
+        <location filename="../../core.cpp" line="473"/>
         <source>Path copied</source>
         <translation>パスがコピーされました</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="644"/>
-        <location filename="../../core.cpp" line="918"/>
-        <location filename="../../core.cpp" line="939"/>
+        <location filename="../../core.cpp" line="647"/>
+        <location filename="../../core.cpp" line="928"/>
+        <location filename="../../core.cpp" line="949"/>
         <source>File exists</source>
         <translation>ファイルは存在します</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="644"/>
+        <location filename="../../core.cpp" line="647"/>
         <source>Overwrite file?</source>
         <translation>ファイルを上書きしますか？</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="812"/>
-        <location filename="../../core.cpp" line="880"/>
+        <location filename="../../core.cpp" line="822"/>
+        <location filename="../../core.cpp" line="890"/>
         <source>Could not create directory </source>
         <translation>ディレクトリを作成できませんでした </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="916"/>
+        <location filename="../../core.cpp" line="926"/>
         <source>File moved.</source>
         <translation>ファイルが移動されました。</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="918"/>
-        <location filename="../../core.cpp" line="939"/>
+        <location filename="../../core.cpp" line="928"/>
+        <location filename="../../core.cpp" line="949"/>
         <source>Destination file exists. Overwrite?</source>
         <translation>移動先にファイルが存在します。上書きしますか？</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="937"/>
+        <location filename="../../core.cpp" line="947"/>
         <source>File copied.</source>
         <translation>ファイルがコピーされました。</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="984"/>
+        <location filename="../../core.cpp" line="994"/>
         <source>Perform action &quot;</source>
         <translation>アクションを実行 &quot;</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="984"/>
+        <location filename="../../core.cpp" line="994"/>
         <source>Changes will be saved immediately.</source>
         <translation>変更はすぐに保存されます。</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1002"/>
+        <location filename="../../core.cpp" line="1012"/>
         <source>Flip horizontal</source>
         <translation>水平方向に反転</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1006"/>
+        <location filename="../../core.cpp" line="1016"/>
         <source>Flip vertical</source>
         <translation>垂直方向に反転</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1010"/>
+        <location filename="../../core.cpp" line="1020"/>
         <source>Rotate</source>
         <translation>回転</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1014"/>
+        <location filename="../../core.cpp" line="1024"/>
         <source>Resize</source>
         <translation>リサイズ</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1020"/>
-        <location filename="../../core.cpp" line="1026"/>
+        <location filename="../../core.cpp" line="1030"/>
+        <location filename="../../core.cpp" line="1036"/>
         <source>Crop</source>
         <translation>切り抜き</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1058"/>
+        <location filename="../../core.cpp" line="1068"/>
         <source>File saved</source>
         <translation>ファイルが保存されました</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1061"/>
+        <location filename="../../core.cpp" line="1071"/>
         <source>Could not save file</source>
         <translation>ファイルを保存できませんでした</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1171"/>
+        <location filename="../../core.cpp" line="1181"/>
         <source>Could not open image</source>
         <translation>画像を開けませんでした</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1175"/>
+        <location filename="../../core.cpp" line="1185"/>
         <source>Can only print static images</source>
         <translation>静止画像のみ印刷できます</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1226"/>
+        <location filename="../../core.cpp" line="1236"/>
         <source>Could not open path: </source>
         <translation>パスを開けませんでした: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1260"/>
+        <location filename="../../core.cpp" line="1270"/>
         <source>Could not load folder: </source>
         <translation>フォルダを読み込めませんでした: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1413"/>
+        <location filename="../../core.cpp" line="1423"/>
         <source>End of directory.</source>
         <translation>ディレクトリの終わり。</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1452"/>
+        <location filename="../../core.cpp" line="1462"/>
         <source>Load failed: </source>
         <translation>読み込みに失敗しました: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1496"/>
+        <location filename="../../core.cpp" line="1506"/>
         <source>Error: could not load image.</source>
         <translation>エラー: 画像を読み込めませんでした。</translation>
     </message>
@@ -324,76 +327,91 @@
     <name>CropPanel</name>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="107"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="370"/>
         <source>Selection</source>
         <translation>選択範囲</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="125"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="371"/>
         <source>Width</source>
         <translation>幅</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="161"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="372"/>
         <source>Height</source>
         <translation>高さ</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="322"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="374"/>
         <source>Aspect Ratio</source>
         <translation>アスペクト比</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="336"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="375"/>
         <source>Free</source>
         <translation>自由</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="341"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="376"/>
         <source>Custom</source>
         <translation>カスタム</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="346"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="377"/>
         <source>Current Image</source>
         <translation>現在の画像</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="351"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="378"/>
         <source>This Screen</source>
         <translation>この画面</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="356"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="379"/>
         <source>1:1</source>
-        <translation></translation>
+        <translation type="unfinished">1:1</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="361"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="380"/>
         <source>4:3</source>
-        <translation></translation>
+        <translation type="unfinished">4:3</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="366"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="381"/>
         <source>16:9</source>
-        <translation></translation>
+        <translation type="unfinished">16:9</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="371"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="382"/>
         <source>16:10</source>
-        <translation></translation>
+        <translation type="unfinished">16:10</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="499"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="385"/>
         <source>Crop</source>
         <translation>切り抜き</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="512"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="386"/>
         <source>Crop &amp;&amp; Save</source>
         <translation>切り抜きと保存</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="527"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="387"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
@@ -402,11 +420,13 @@
     <name>FVOptionsPopup</name>
     <message>
         <location filename="../../gui/folderview/fvoptionspopup.ui" line="32"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_fvoptionspopup.h" line="86"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/fvoptionspopup.ui" line="53"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_fvoptionspopup.h" line="87"/>
         <source>View options</source>
         <translation>表示オプション</translation>
     </message>
@@ -415,56 +435,67 @@
     <name>FileReplaceDialog</name>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="14"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="130"/>
         <source>Dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="20"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="131"/>
         <source>title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="33"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="132"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="40"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="133"/>
         <source>src</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="50"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="134"/>
         <source>&gt;&gt;&gt;</source>
         <translation>&gt;&gt;&gt;</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="63"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="135"/>
         <source>Destination:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="70"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="136"/>
         <source>dst</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="111"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="137"/>
         <source>Apply to all</source>
         <translation>すべてに適用</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="118"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="138"/>
         <source>Yes</source>
         <translation>はい</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="125"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="139"/>
         <source>No</source>
         <translation>いいえ</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="132"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="140"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
@@ -473,77 +504,93 @@
     <name>FolderView</name>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="17"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="410"/>
         <source>Form</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="145"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="411"/>
         <source>[path]</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="195"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="413"/>
         <source>FolderViewSlider</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="242"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="416"/>
         <source>CheckableButton</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="274"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="426"/>
         <source>PanelComboBox</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="281"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="418"/>
         <source>A - Z</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="286"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="419"/>
         <source>Z - A</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="291"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="420"/>
         <source>Size</source>
         <translation>サイズ</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="296"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="421"/>
         <source>Size (desc)</source>
         <translation>サイズ (降順)</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="301"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="422"/>
         <source>Oldest</source>
         <translation>古い順</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="306"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="423"/>
         <source>Newest</source>
         <translation>新しい順</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="348"/>
         <location filename="../../gui/folderview/folderview.ui" line="373"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="429"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="432"/>
         <source>PanelButton</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="414"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="435"/>
         <source>PanelButtonRE</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="476"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="438"/>
         <source>PlacesPanel</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="532"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="440"/>
         <source>BOOKMARKS</source>
         <translation>お気に入り</translation>
     </message>
@@ -551,11 +598,15 @@
         <location filename="../../gui/folderview/folderview.ui" line="551"/>
         <location filename="../../gui/folderview/folderview.ui" line="638"/>
         <location filename="../../gui/folderview/folderview.ui" line="657"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="442"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="446"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="449"/>
         <source>PlacesPanelButton</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="611"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="444"/>
         <source>FILESYSTEM</source>
         <translation>ファイルシステム</translation>
     </message>
@@ -564,11 +615,13 @@
     <name>ImageInfoOverlay</name>
     <message>
         <location filename="../../gui/overlays/imageinfooverlay.ui" line="65"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_imageinfooverlay.h" line="111"/>
         <source>OverlayHeaderWidget</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/overlays/imageinfooverlay.ui" line="99"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_imageinfooverlay.h" line="113"/>
         <source>EXIF Tags</source>
         <translation>EXIFタグ</translation>
     </message>
@@ -584,35 +637,35 @@
 <context>
     <name>MW</name>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="565"/>
+        <location filename="../../gui/mainwindow.cpp" line="581"/>
         <source>Save File as...</source>
         <translation>名前を付けてファイルを保存</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="800"/>
+        <location filename="../../gui/mainwindow.cpp" line="816"/>
         <source>Folder view</source>
         <translation>フォルダービュー</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="801"/>
-        <location filename="../../gui/mainwindow.cpp" line="802"/>
-        <location filename="../../gui/mainwindow.cpp" line="805"/>
-        <location filename="../../gui/mainwindow.cpp" line="806"/>
+        <location filename="../../gui/mainwindow.cpp" line="817"/>
+        <location filename="../../gui/mainwindow.cpp" line="818"/>
+        <location filename="../../gui/mainwindow.cpp" line="821"/>
+        <location filename="../../gui/mainwindow.cpp" line="822"/>
         <source>No file opened.</source>
         <translation>ファイルが開かれていません。</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="867"/>
+        <location filename="../../gui/mainwindow.cpp" line="883"/>
         <source>Fit Window</source>
         <translation>ウィンドウに合わせる</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="871"/>
+        <location filename="../../gui/mainwindow.cpp" line="887"/>
         <source>Fit Width</source>
         <translation>幅に合わせる</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="875"/>
+        <location filename="../../gui/mainwindow.cpp" line="891"/>
         <source>Fit 1:1</source>
         <translation>1:1表示</translation>
     </message>
@@ -621,71 +674,85 @@
     <name>PrintDialog</name>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="20"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="304"/>
         <source>Print image</source>
         <translation>画像を印刷</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="126"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="306"/>
         <source>Preview</source>
         <translation>プレビュー</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="179"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="307"/>
         <source>Printer:</source>
         <translation>プリンター:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="189"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="308"/>
         <source>&lt;No printers found&gt;</source>
         <translation>&lt;プリンターが見つかりません&gt;</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="271"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="309"/>
         <source>Page orientation:</source>
         <translation>ページの向き:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="297"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="310"/>
         <source>Portrait</source>
         <translation>縦</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="307"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="311"/>
         <source>Landscape</source>
         <translation>横</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="348"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="312"/>
         <source>Color mode:</source>
         <translation>カラーモード:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="374"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="313"/>
         <source>Grayscale</source>
         <translation>グレースケール</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="384"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="314"/>
         <source>Color</source>
         <translation>カラー</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="409"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="315"/>
         <source>Fit to page</source>
         <translation>ページに合わせる</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="434"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="316"/>
         <source>Export PDF</source>
         <translation>PDFにエクスポート</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="454"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="317"/>
         <source>Print</source>
         <translation>印刷</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="464"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="318"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
@@ -825,11 +892,14 @@
     <message>
         <location filename="../../gui/overlays/renameoverlay.ui" line="171"/>
         <location filename="../../gui/overlays/renameoverlay.ui" line="260"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_renameoverlay.h" line="213"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_renameoverlay.h" line="214"/>
         <source>Rename</source>
         <translation>名前の変更</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/renameoverlay.ui" line="273"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_renameoverlay.h" line="215"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
@@ -838,151 +908,181 @@
     <name>ResizeDialog</name>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="32"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="358"/>
         <source>Resize</source>
         <translation>リサイズ</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="63"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="359"/>
         <source>By Percent:</source>
         <translation>パーセントで:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="79"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="360"/>
         <source>By Absolute Size:</source>
         <translation>絶対サイズで:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="98"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="361"/>
         <source>Percent:</source>
         <translation>パーセント:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="119"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="362"/>
         <source>Width:</source>
         <translation>幅:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="205"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="363"/>
         <source>Height:</source>
         <translation>高さ:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="275"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="364"/>
         <source>Keep aspect ratio</source>
         <translation>アスペクト比を維持</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="304"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="365"/>
         <source>Filter:</source>
         <translation>フィルター:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="330"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="366"/>
         <source>Nearest</source>
         <translation>最近傍</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="335"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="367"/>
         <source>Bilinear</source>
         <translation>バイリニア</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="340"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="368"/>
         <source>Bicubic</source>
         <translation>バイキュービック</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="345"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="369"/>
         <source>Lanczos3</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="358"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="371"/>
         <source>Common sizes:</source>
         <translation>一般的なサイズ:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="392"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="372"/>
         <source>Select:</source>
         <translation>選択:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="397"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="373"/>
         <source>1366 x 768</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="402"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="374"/>
         <source>1440 x 900</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="407"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="375"/>
         <source>1440 x 1050</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="412"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="376"/>
         <source>1600 x 1200</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="417"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="377"/>
         <source>1920 x 1080 (FullHD)</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="422"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="378"/>
         <source>1920 x 1200 (FullHD)</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="427"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="379"/>
         <source>2560 x 1080</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="432"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="380"/>
         <source>2560 x 1440</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="437"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="381"/>
         <source>2560 x 1600</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="442"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="382"/>
         <source>3840 x 1600 (UW 4K)</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="447"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="383"/>
         <source>3840 x 2160 (UHD-1)</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="470"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="385"/>
         <source>Fit to desktop</source>
         <translation>デスクトップに合わせる</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="489"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="386"/>
         <source>Fill desktop (expanding)</source>
         <translation>デスクトップに合わせる (拡大)</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="508"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="387"/>
         <source>Reset</source>
         <translation>リセット</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="575"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="388"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="594"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="389"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
@@ -1034,21 +1134,25 @@
     <name>SaveConfirmOverlay</name>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="81"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="145"/>
         <source>Unsaved edits</source>
         <translation>未保存の編集</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="127"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="146"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="140"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="147"/>
         <source>Save as</source>
         <translation>名前を付けて保存</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="169"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="148"/>
         <source>Discard</source>
         <translation>破棄</translation>
     </message>
@@ -1057,31 +1161,37 @@
     <name>ScriptEditorDialog</name>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="48"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="208"/>
         <source>Command:</source>
         <translation>コマンド:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="84"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="209"/>
         <source>NOTE: make sure your .sh script has execute flag.</source>
         <translation>注意: .shスクリプトに実行権限が付与されていることを確認してください。</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="91"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="210"/>
         <source>Name:</source>
         <translation>名前:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="148"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="212"/>
         <source>Wait to finish</source>
         <translation>完了を待つ</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="218"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="214"/>
         <source>Create</source>
         <translation>作成</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="225"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="215"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
@@ -1126,747 +1236,934 @@
     <name>SettingsDialog</name>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="47"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2892"/>
         <source>Preferences</source>
         <translation>設定</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="53"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2894"/>
         <source>SettingsDialog</source>
         <translation>設定ダイアログ</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="339"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2900"/>
         <source>General</source>
         <translation>一般</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="415"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2901"/>
         <source>Language:</source>
         <translation>言語:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="435"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2902"/>
         <source>Requires application restart</source>
         <translation>再起動が必要です</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="473"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2903"/>
         <source>Open in fullscreen</source>
         <translation>フルスクリーンで開く</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="480"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2904"/>
         <source>Start in folder view by default</source>
         <translation>デフォルトでフォルダービューで起動</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="551"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2905"/>
         <source>User interface</source>
         <translation>ユーザーインターフェース</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="606"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2906"/>
         <source>Image info in window title</source>
         <translation>ウィンドウタイトルに画像情報を表示</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="626"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2907"/>
         <source>Auto-hide cursor</source>
         <translation>カーソルを自動的に隠す</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="633"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2909"/>
         <source>Turn this off if you are using a touchpad with libinput driver.</source>
         <translation>libinputドライバー付きのタッチパッドを使用している場合は、これをオフにしてください。</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="636"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2911"/>
         <source>Enable smooth scrolling</source>
         <translation>スムーズスクロールを有効にする</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="643"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2912"/>
         <source>Fullscreen info bar</source>
         <translation>フルスクリーン情報バー</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="656"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2913"/>
         <source>Status bar</source>
         <translation>ステータスバー</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="689"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2914"/>
         <source>Zoom indicator:</source>
         <translation>ズームインジケーター:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="699"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2915"/>
         <source>On</source>
         <translation>オン</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="706"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2916"/>
         <source>Off</source>
         <translation>オフ</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="713"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2917"/>
         <source>Auto</source>
         <translation>自動</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="753"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2918"/>
         <source>Automatic window resize</source>
         <translation>ウィンドウの自動リサイズ</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="763"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2919"/>
         <source>Match displayed content</source>
         <translation>表示内容に合わせる</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="799"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2920"/>
         <source>Screen area limit for auto resize:</source>
         <translation>自動リサイズのための画面領域制限:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="864"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2240"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2261"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2921"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2978"/>
         <source>xx</source>
         <translation>xx</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="962"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2925"/>
         <source>Thumbnail panel</source>
         <translation>サムネイルパネル</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1018"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2926"/>
         <source>Crop previews</source>
         <translation>プレビューを切り抜く</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1031"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2927"/>
         <source>Pinned</source>
         <translation>ピン留め</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1050"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2928"/>
         <source>Disable in windowed mode</source>
         <translation>ウィンドウモードでは無効</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1057"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2929"/>
         <source>Center selected image</source>
         <translation>選択した画像を中央に配置</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1109"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2930"/>
         <source>Extended</source>
         <translation>拡張</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1119"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2931"/>
         <source>Previews only</source>
         <translation>プレビューのみ</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1126"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2932"/>
         <source>Display style:</source>
         <translation>表示スタイル:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1139"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2933"/>
         <source>Show filename and resolution</source>
         <translation>ファイル名と解像度を表示</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1159"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2934"/>
         <source>Simple</source>
         <translation>シンプル</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1183"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2935"/>
         <source>Preview size:</source>
         <translation>プレビューサイズ:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1258"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2936"/>
         <source>Position:</source>
         <translation>位置:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1266"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2064"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2085"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2937"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2972"/>
         <source>Top</source>
         <translation>上</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1271"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2938"/>
         <source>Bottom</source>
         <translation>下</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1276"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2939"/>
         <source>Left</source>
         <translation>左</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1281"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2940"/>
         <source>Right</source>
         <translation>右</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1374"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2942"/>
         <source>Folder navigation</source>
         <translation>フォルダーナビゲーション</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1400"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2943"/>
         <source>Stop</source>
         <translation>停止</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1410"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2944"/>
         <source>Loop folder</source>
         <translation>フォルダーをループ</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1417"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2945"/>
         <source>Go to the next folder</source>
         <translation>次のフォルダーへ</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1424"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2946"/>
         <source>After reaching the end:</source>
         <translation>最後の画像に達した後:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1476"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2947"/>
         <source>Default sorting mode:</source>
         <translation>デフォルトの並べ替えモード:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1493"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2948"/>
         <source>A - Z</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1498"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2949"/>
         <source>Z - A</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1503"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2950"/>
         <source>Size</source>
         <translation>サイズ</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1508"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2951"/>
         <source>Size (desc)</source>
         <translation>サイズ (降順)</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1513"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2952"/>
         <source>Oldest</source>
         <translation>古い順</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1518"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2953"/>
         <source>Newest</source>
         <translation>新しい順</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1541"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2955"/>
         <source>Apply sorting to folders</source>
         <translation>フォルダーに並べ替えを適用</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1609"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1555"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2956"/>
+        <source>Show hidden files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1623"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2957"/>
         <source>Video playback</source>
         <translation>ビデオ再生</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1651"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1665"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2958"/>
         <source>Play sounds</source>
         <translation>サウンドを再生</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1720"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1734"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2959"/>
         <source>Slideshow</source>
         <translation>スライドショー</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1740"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1754"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2960"/>
         <source>Switch interval:</source>
         <translation>切り替え間隔:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1771"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1785"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2961"/>
         <source>ms</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1803"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1817"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2962"/>
         <source>Loop slideshow</source>
         <translation>スライドショーをループ</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1900"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1914"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2963"/>
         <source>View</source>
         <translation>表示</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1956"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1970"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2964"/>
         <source>Display options</source>
         <translation>表示オプション</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1980"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1994"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2965"/>
         <source>Image fit:</source>
         <translation>画像のフィット:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1987"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2001"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2966"/>
         <source>Fit in window</source>
         <translation>ウィンドウに合わせる</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1997"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2011"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2967"/>
         <source>Stretch to width</source>
         <translation>幅に合わせる</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2004"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2018"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2968"/>
         <source>1:1</source>
-        <translation></translation>
+        <translation type="unfinished">1:1</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2026"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2025"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2969"/>
+        <source>Fit in window (stretch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2047"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2970"/>
         <source>Keep fit mode when switching images</source>
         <translation>画像切り替え時にフィットモードを維持</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2057"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2078"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2971"/>
         <source>Focus in 1:1 mode:</source>
         <translation>1:1モードでのフォーカス:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2071"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2092"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2973"/>
         <source>Center</source>
         <translation>中央</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2078"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2099"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2974"/>
         <source>At cursor</source>
         <translation>カーソル位置</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2103"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2124"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2975"/>
         <source>Part of image that&apos;s focused after switching to 1:1</source>
         <translation>1:1表示に切り替えた際の焦点部分</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2126"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2147"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2976"/>
         <source>Grid background on images with transparency</source>
         <translation>透明な画像にグリッド背景を表示</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2163"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2184"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2977"/>
         <source>Expand images, up to:</source>
         <translation>画像を拡大、最大:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2271"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2292"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2979"/>
         <source>Images smaller than window will be zoomed in</source>
         <translation>ウィンドウより小さい画像は拡大表示されます</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2323"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2344"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2980"/>
         <source>Zoom options</source>
         <translation>ズームオプション</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2330"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2351"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2981"/>
         <source>Unlock minimum zoom</source>
         <translation>最小ズームを解除</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2340"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2361"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2982"/>
         <source>Always allow zooming below 100%</source>
         <translation>常に100%未満のズームを許可</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2365"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2386"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2983"/>
         <source>Zoom step:</source>
         <translation>ズームステップ:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2433"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2454"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2984"/>
         <source>[step]</source>
         <translation>[ステップ]</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2462"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2483"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2985"/>
         <source>Use fixed zoom levels:</source>
         <translation>固定ズームレベルを使用:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2506"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2527"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2986"/>
         <source>Load defaults</source>
         <translation>デフォルトを読み込む</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2574"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2595"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2987"/>
         <source>Scaling quality</source>
         <translation>スケーリング品質</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2601"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2622"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2991"/>
         <source>Scaling filter:</source>
         <translation>スケーリングフィルター:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2633"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2654"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2992"/>
         <source>Nearest neighbor</source>
         <translation>最近傍補間</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2638"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2659"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2993"/>
         <source>Bilinear</source>
         <translation>バイリニア</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2680"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2701"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2999"/>
         <source>When unchecked, nearest neighbor algorithm will be used for upscaling.</source>
         <translation>チェックを外すと、アップスケーリングに最近傍補間が使用されます。</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2683"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2704"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3001"/>
         <source>Smooth upscaling</source>
         <translation>スムーズなアップスケーリング</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2702"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2723"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3002"/>
         <source>Smooth animated images</source>
         <translation>アニメーション画像をスムーズにする</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2781"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2802"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3003"/>
         <source>Theme</source>
         <translation>テーマ</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2840"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2861"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3004"/>
         <source>Load preset:</source>
         <translation>プリセットを読み込む:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2853"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2857"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2874"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2878"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3005"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3010"/>
         <source>Black</source>
         <translation>黒</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2862"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2883"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3006"/>
         <source>Dark</source>
         <translation>ダーク</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2867"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2888"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3007"/>
         <source>Dark Blue</source>
         <translation>ダークブルー</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2872"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2893"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3008"/>
         <source>Light</source>
         <translation>ライト</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2896"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2917"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3011"/>
         <source>Use system colors</source>
         <translation>システムカラーを使用</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2906"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2927"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3012"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;modify&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;変更&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3132"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3153"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3015"/>
         <source>Accent</source>
         <translation>アクセント</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3139"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3160"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3016"/>
         <source>Background</source>
         <translation>背景</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3146"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3167"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3017"/>
         <source>Background (fullscreen mode)</source>
         <translation>背景 (フルスクリーンモード)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3184"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3205"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3019"/>
         <source>Text</source>
         <translation>テキスト</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3191"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3212"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3020"/>
         <source>Icons</source>
         <translation>アイコン</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3291"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3312"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3024"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="62"/>
         <source>Overlay background</source>
         <translation>オーバーレイ背景</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3329"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3350"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3026"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="60"/>
         <source>Widget background</source>
         <translation>ウィジェットの背景</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3336"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3357"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3027"/>
         <source>Folder view top panel</source>
         <translation>フォルダービューのトップパネル</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3343"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3364"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3028"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="61"/>
         <source>Widget border</source>
         <translation>ウィジェットの境界線</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3412"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3433"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3031"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="63"/>
         <source>Overlay text</source>
         <translation>オーバーレイテキスト</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3450"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3471"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3033"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="64"/>
         <source>Scrollbars</source>
         <translation>スクロールバー</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3457"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3478"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3034"/>
         <source>Folder view background</source>
         <translation>フォルダービューの背景</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3528"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3549"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3035"/>
         <source>Other window tweaks</source>
         <translation>その他のウィンドウの調整</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3543"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3564"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3036"/>
         <source>Window opacity:</source>
         <translation>ウィンドウの不透明度:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3596"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3617"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3037"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3621"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3642"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3038"/>
         <source>Background blur (KDE)</source>
         <translation>背景のぼかし (KDE)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3673"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3694"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3039"/>
         <source>Controls</source>
         <translation>コントロール</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3734"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4073"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3755"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4200"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3040"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3063"/>
         <source>Add</source>
         <translation>追加</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3741"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4080"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3762"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4207"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3041"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3064"/>
         <source>Edit</source>
         <translation>編集</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3754"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4087"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3775"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4214"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3042"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3065"/>
         <source>Remove</source>
         <translation>削除</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3783"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3804"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3043"/>
         <source>Reset to defaults</source>
         <translation>デフォルトにリセット</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3817"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3838"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3045"/>
         <source>Action</source>
         <translation>アクション</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3822"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3843"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3047"/>
         <source>Shortcut</source>
         <translation>ショートカット</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3874"/>
-        <source>Mouse &amp; touchpad</source>
-        <translation>マウスとタッチパッド</translation>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3898"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3048"/>
+        <source>Switch image by clicking window edges</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3895"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3905"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3049"/>
+        <source>Visible edges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mouse &amp; touchpad</source>
+        <translation type="vanished">マウスとタッチパッド</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3935"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3050"/>
         <source>Scroll image with:</source>
         <translation>画像スクロール:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3903"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3943"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3051"/>
         <source>None</source>
         <translation>なし</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3908"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3948"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3052"/>
         <source>Touchpad</source>
         <translation>タッチパッド</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3913"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3953"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3053"/>
         <source>Touchpad &amp; Mouse Wheel</source>
         <translation>タッチパッドとマウスホイール</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3939"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3979"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3055"/>
         <source>Note: you can also zoom by holding RMB and moving the mouse</source>
         <translation>注意: 右クリックを押しながらマウスを動かすことでもズームできます</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3953"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4007"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3056"/>
+        <source>Mouse scrolling speed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4051"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3057"/>
+        <source>[x]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4080"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3058"/>
         <source>Trackpad detection</source>
         <translation>トラックパッドの検出</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3963"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4090"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3059"/>
         <source>Disable if you have issues with mouse scrolling</source>
         <translation>マウススクロールに問題がある場合は無効にしてください</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3995"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4122"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3060"/>
         <source>Scripts</source>
         <translation>スクリプト</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4051"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4178"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3061"/>
         <source>Note: these will appear in &quot;Open with&quot; menu.</source>
         <translation type="unfinished">注意: これらは「スクリプト/アプリで開く」メニューに表示されます。</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4061"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4188"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3062"/>
         <source>Also, you can assign shortcuts to scripts (in &quot;Controls&quot; section).</source>
         <translation>また、「コントロール」セクションでスクリプトにショートカットを割り当てることもできます。</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4170"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4297"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3066"/>
         <source>Advanced</source>
         <translation>詳細</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4227"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4354"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3068"/>
         <source>Preload the next/previous image. Results in a much faster image switching (at the expense of wasting more RAM).</source>
         <translation>次/前の画像をプリロードします。これにより、画像の切り替えが大幅に高速化されます（RAMをより多く消費します）。</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4230"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4357"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3070"/>
         <source>Use preloader (recommended)</source>
         <translation>プリローダーを使用する（推奨）</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4240"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4367"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3071"/>
         <source>Load adjacent images in background</source>
         <translation>隣接する画像をバックグラウンドで読み込む</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4268"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4395"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3072"/>
         <source>Thumbnailer thread count:</source>
         <translation>サムネイル生成のスレッド数:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4306"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4433"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3073"/>
         <source>2</source>
         <translation>2</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4337"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4464"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3077"/>
         <source>Use thumbnail cache (recommended)</source>
         <translation>サムネイルキャッシュを使用する（推奨）</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4344"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4471"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3078"/>
         <source>Unload off-screen thumbnails</source>
         <translation>画面外のサムネイルをアンロードする</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4354"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4481"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3079"/>
         <source>Dynamically unload items to save memory</source>
         <translation>メモリを節約するために動的にアイテムをアンロードする</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4368"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4495"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3080"/>
         <source>Show save overlay when editing images</source>
         <translation>画像編集中に保存オーバーレイを表示</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4383"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4510"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3081"/>
         <source>JPEG save quality:</source>
         <translation>JPEG保存品質:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4427"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4554"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3082"/>
         <source>q</source>
         <translation>q</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4456"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4583"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3083"/>
         <source>Confirm moving to trash</source>
         <translation>ゴミ箱への移動を確認</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4468"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4595"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3084"/>
         <source>Confirm file delete (!)</source>
         <translation>ファイルの削除を確認 (!)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4482"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4609"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3085"/>
         <source>JXL animation support (experimental)</source>
         <translation>JXLアニメーションサポート（実験的）</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4510"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4637"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3086"/>
         <source>Memory allocation limit per image, MB:</source>
         <translation>画像あたりのメモリ割り当て制限（MB）:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4571"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4698"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3087"/>
         <source>Mpv binary:</source>
         <translation>Mpvバイナリ:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4612"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4739"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3088"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4706"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4833"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3089"/>
         <source>About qimgv</source>
         <translation>qimgvについて</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4757"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4884"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3090"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -1905,17 +2202,20 @@ li.checked::marker { content: &quot;\2612&quot;; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:10pt;&quot;&gt;問題の報告や機能のリクエストは&lt;/span&gt;&lt;a href=&quot;https://github.com/easymodo/qimgv/issues&quot;&gt;&lt;span style=&quot; font-family:&apos;Droid Sans&apos;; font-size:10pt; text-decoration: underline; color:#007af4;&quot;&gt;こちら&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4850"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4977"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3112"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4857"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4984"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3113"/>
         <source>Apply</source>
         <translation>適用</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4864"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4991"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3114"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
@@ -1955,40 +2255,50 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>テキストの色</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.cpp" line="569"/>
+        <location filename="../../gui/dialogs/settingsdialog.cpp" line="590"/>
         <source>Edit shortcut</source>
         <translation>ショートカットを編集</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.cpp" line="620"/>
+        <location filename="../../gui/dialogs/settingsdialog.cpp" line="641"/>
         <source>Navigate to mpv binary</source>
         <translation>mpvバイナリに移動</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.cpp" line="649"/>
+        <source>Maximum</source>
+        <translation>最大</translation>
     </message>
 </context>
 <context>
     <name>ShortcutCreatorDialog</name>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="14"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="148"/>
         <source>New shortcut</source>
         <translation>新しいショートカット</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="34"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="149"/>
         <source>Action:</source>
         <translation>アクション:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="73"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="150"/>
         <source>Script:</source>
         <translation>スクリプト:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="117"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="151"/>
         <source>Shortcut:</source>
         <translation>ショートカット:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="124"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="152"/>
         <source>[Enter shortcut]</source>
         <translation>[ショートカットを入力]</translation>
     </message>
@@ -1996,32 +2306,32 @@ li.checked::marker { content: &quot;\2612&quot;; }
 <context>
     <name>main</name>
     <message>
-        <location filename="../../main.cpp" line="133"/>
+        <location filename="../../main.cpp" line="126"/>
         <source>File or directory path.</source>
         <translation>ファイルまたはディレクトリのパス。</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="136"/>
+        <location filename="../../main.cpp" line="129"/>
         <source>Generate all thumbnails for directory.</source>
         <translation>ディレクトリのすべてのサムネイルを生成します。</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="137"/>
+        <location filename="../../main.cpp" line="130"/>
         <source>directory-path</source>
         <translation>ディレクトリパス</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="139"/>
+        <location filename="../../main.cpp" line="132"/>
         <source>Thumbnail size. Current size is used if not specified.</source>
         <translation>サムネイルサイズ。指定しない場合は現在のサイズが使用されます。</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="140"/>
+        <location filename="../../main.cpp" line="133"/>
         <source>thumbnail-size</source>
         <translation>サムネイルサイズ</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="142"/>
+        <location filename="../../main.cpp" line="135"/>
         <source>Show build options.</source>
         <translation>ビルドオプションを表示します。</translation>
     </message>

--- a/qimgv/res/translations/tr_TR.ts
+++ b/qimgv/res/translations/tr_TR.ts
@@ -5,11 +5,13 @@
     <name>ChangelogWindow</name>
     <message>
         <location filename="../../gui/overlays/changelogwindow.ui" line="154"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_changelogwindow.h" line="137"/>
         <source>Close, never show changelogs</source>
         <translation>Kapat, değişiklik günlüğünü asla gösterme</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/changelogwindow.ui" line="170"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_changelogwindow.h" line="138"/>
         <source>Close</source>
         <translation>Kapat</translation>
     </message>
@@ -17,62 +19,63 @@
 <context>
     <name>ContextMenu</name>
     <message>
-        <location filename="../../gui/contextmenu.ui" line="229"/>
+        <location filename="../../gui/contextmenu.ui" line="236"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_contextmenu.h" line="449"/>
         <source>Edit</source>
         <translation>Düzenle</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="55"/>
+        <location filename="../../gui/contextmenu.cpp" line="58"/>
         <source>Print</source>
         <translation>Yazdır</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="59"/>
+        <location filename="../../gui/contextmenu.cpp" line="62"/>
         <source>Quick copy</source>
         <translation>Hızlı kopyala</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="63"/>
+        <location filename="../../gui/contextmenu.cpp" line="66"/>
         <source>Quick move</source>
         <translation>Hızlı taşı</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="67"/>
+        <location filename="../../gui/contextmenu.cpp" line="70"/>
         <source>Move to trash</source>
         <translation>Çöp kutusuna taşı</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="72"/>
+        <location filename="../../gui/contextmenu.cpp" line="75"/>
         <source>Open</source>
         <translation>Aç</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="77"/>
+        <location filename="../../gui/contextmenu.cpp" line="80"/>
         <source>Folder View</source>
         <translation>Klasör görünümü</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="82"/>
+        <location filename="../../gui/contextmenu.cpp" line="85"/>
         <source>Settings</source>
         <translation>Ayarlar</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="85"/>
+        <location filename="../../gui/contextmenu.cpp" line="88"/>
         <source>Open with...</source>
         <translation>Birlikte aç...</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="91"/>
+        <location filename="../../gui/contextmenu.cpp" line="94"/>
         <source>Show in folder</source>
         <translation>Bulunduğu klasörü aç</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="99"/>
+        <location filename="../../gui/contextmenu.cpp" line="102"/>
         <source>Back</source>
         <translation>Geri</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="102"/>
+        <location filename="../../gui/contextmenu.cpp" line="105"/>
         <source>Configure menu</source>
         <translation>Menüyü düzenle</translation>
     </message>
@@ -94,228 +97,228 @@
 <context>
     <name>Core</name>
     <message>
-        <location filename="../../core.cpp" line="255"/>
+        <location filename="../../core.cpp" line="258"/>
         <source>Updated: </source>
         <translation>Güncellendi: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="261"/>
+        <location filename="../../core.cpp" line="264"/>
         <source>Welcome to </source>
         <translation>Hoş geldiniz</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="261"/>
+        <location filename="../../core.cpp" line="264"/>
         <source> version </source>
         <translation> sürüm </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="268"/>
+        <location filename="../../core.cpp" line="271"/>
         <source>Shuffle mode: OFF</source>
         <translation>Karıştırma modu: KAPALI</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="271"/>
+        <location filename="../../core.cpp" line="274"/>
         <source>Shuffle mode: ON</source>
         <translation>Karıştırma modu: AÇIK</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="280"/>
+        <location filename="../../core.cpp" line="283"/>
         <source>Slideshow: OFF</source>
         <translation>Slayt gösterisi: KAPALI</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="284"/>
+        <location filename="../../core.cpp" line="287"/>
         <source>Slideshow: ON</source>
         <translation>Slayt gösterisi: AÇIK</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="355"/>
+        <location filename="../../core.cpp" line="358"/>
         <source>Delete </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="355"/>
+        <location filename="../../core.cpp" line="358"/>
         <source> items permanently?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="357"/>
+        <location filename="../../core.cpp" line="360"/>
         <source>Delete item permanently?</source>
         <translation>Kalıcı olarak silmek istiyor musunuz?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="358"/>
+        <location filename="../../core.cpp" line="361"/>
         <source>Delete permanently</source>
         <translation>Kalıcı olarak sil</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="374"/>
+        <location filename="../../core.cpp" line="377"/>
         <source>File removed</source>
         <translation>Dosya kaldırıldı</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="378"/>
+        <location filename="../../core.cpp" line="381"/>
         <source>Removed: </source>
         <translation>Kaldırıldı: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="378"/>
-        <location filename="../../core.cpp" line="408"/>
+        <location filename="../../core.cpp" line="381"/>
+        <location filename="../../core.cpp" line="411"/>
         <source> files</source>
         <translation> dosya</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="389"/>
+        <location filename="../../core.cpp" line="392"/>
         <source>Move </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="389"/>
+        <location filename="../../core.cpp" line="392"/>
         <source> items to trash?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="391"/>
+        <location filename="../../core.cpp" line="394"/>
         <source>Move item to trash?</source>
         <translation>Öğeyi çöp kutusuna taşımak istiyor musunuz?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="392"/>
+        <location filename="../../core.cpp" line="395"/>
         <source>Move to trash</source>
         <translation>Çöp kutusuna taşı</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="404"/>
+        <location filename="../../core.cpp" line="407"/>
         <source>Moved to trash</source>
         <translation>Çöp kutusuna taşındı</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="408"/>
+        <location filename="../../core.cpp" line="411"/>
         <source>Moved to trash: </source>
         <translation>Çöp kutusuna taşındı: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="463"/>
+        <location filename="../../core.cpp" line="466"/>
         <source>File copied</source>
         <translation>Dosya kopyalandı</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="470"/>
+        <location filename="../../core.cpp" line="473"/>
         <source>Path copied</source>
         <translation>Dosya yolu kopyalandı</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="644"/>
-        <location filename="../../core.cpp" line="918"/>
-        <location filename="../../core.cpp" line="939"/>
+        <location filename="../../core.cpp" line="647"/>
+        <location filename="../../core.cpp" line="928"/>
+        <location filename="../../core.cpp" line="949"/>
         <source>File exists</source>
         <translation>Dosya zaten var</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="644"/>
+        <location filename="../../core.cpp" line="647"/>
         <source>Overwrite file?</source>
         <translation>Dosyanın üzerine yazılsın mı?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="812"/>
-        <location filename="../../core.cpp" line="880"/>
+        <location filename="../../core.cpp" line="822"/>
+        <location filename="../../core.cpp" line="890"/>
         <source>Could not create directory </source>
         <translation>Dizin oluşturulamadı </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="916"/>
+        <location filename="../../core.cpp" line="926"/>
         <source>File moved.</source>
         <translation>Dosya taşındı.</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="918"/>
-        <location filename="../../core.cpp" line="939"/>
+        <location filename="../../core.cpp" line="928"/>
+        <location filename="../../core.cpp" line="949"/>
         <source>Destination file exists. Overwrite?</source>
         <translation>Dosya hedefte var. Üzerine yazılsın mı?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="937"/>
+        <location filename="../../core.cpp" line="947"/>
         <source>File copied.</source>
         <translation>Dosya kopyalandı.</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="984"/>
+        <location filename="../../core.cpp" line="994"/>
         <source>Perform action &quot;</source>
         <translation>Eylemi gerçekleştir: &quot;</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="984"/>
+        <location filename="../../core.cpp" line="994"/>
         <source>Changes will be saved immediately.</source>
         <translation>Değişiklikler hemen kaydedilecektir.</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1002"/>
+        <location filename="../../core.cpp" line="1012"/>
         <source>Flip horizontal</source>
         <translation>Yatay çevir</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1006"/>
+        <location filename="../../core.cpp" line="1016"/>
         <source>Flip vertical</source>
         <translation>Dikey çevir</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1010"/>
+        <location filename="../../core.cpp" line="1020"/>
         <source>Rotate</source>
         <translation>Döndür</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1014"/>
+        <location filename="../../core.cpp" line="1024"/>
         <source>Resize</source>
         <translation>Yeniden boyutlandır</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1020"/>
-        <location filename="../../core.cpp" line="1026"/>
+        <location filename="../../core.cpp" line="1030"/>
+        <location filename="../../core.cpp" line="1036"/>
         <source>Crop</source>
         <translation>Kırp</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1058"/>
+        <location filename="../../core.cpp" line="1068"/>
         <source>File saved</source>
         <translation>Dosya kaydedildi</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1061"/>
+        <location filename="../../core.cpp" line="1071"/>
         <source>Could not save file</source>
         <translation>Dosya kaydedilemedi</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1171"/>
+        <location filename="../../core.cpp" line="1181"/>
         <source>Could not open image</source>
         <translation>Görüntü açılamadı</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1175"/>
+        <location filename="../../core.cpp" line="1185"/>
         <source>Can only print static images</source>
         <translation>Sadece hareketsiz görüntüler yazdırılabilir</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1226"/>
+        <location filename="../../core.cpp" line="1236"/>
         <source>Could not open path: </source>
         <translation>Dosya yolu açılamadı: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1260"/>
+        <location filename="../../core.cpp" line="1270"/>
         <source>Could not load folder: </source>
         <translation>Klasör yüklenemedi: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1413"/>
+        <location filename="../../core.cpp" line="1423"/>
         <source>End of directory.</source>
         <translation>Dizin sonu.</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1452"/>
+        <location filename="../../core.cpp" line="1462"/>
         <source>Load failed: </source>
         <translation>Yükleme başarısız: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1496"/>
+        <location filename="../../core.cpp" line="1506"/>
         <source>Error: could not load image.</source>
         <translation>Hata: Görüntü yüklenemedi.</translation>
     </message>
@@ -324,76 +327,91 @@
     <name>CropPanel</name>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="107"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="370"/>
         <source>Selection</source>
         <translation>Seçim</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="125"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="371"/>
         <source>Width</source>
         <translation>Genişlik</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="161"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="372"/>
         <source>Height</source>
         <translation>Yükseklik</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="322"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="374"/>
         <source>Aspect Ratio</source>
         <translation>En boy oranı</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="336"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="375"/>
         <source>Free</source>
         <translation>Serbest</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="341"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="376"/>
         <source>Custom</source>
         <translation>Özel</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="346"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="377"/>
         <source>Current Image</source>
         <translation>Mevcut görüntü</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="351"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="378"/>
         <source>This Screen</source>
         <translation>Bu ekran</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="356"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="379"/>
         <source>1:1</source>
         <translation>1:1</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="361"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="380"/>
         <source>4:3</source>
         <translation>4:3</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="366"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="381"/>
         <source>16:9</source>
         <translation>16:9</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="371"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="382"/>
         <source>16:10</source>
         <translation>16:10</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="499"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="385"/>
         <source>Crop</source>
         <translation>Kırp</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="512"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="386"/>
         <source>Crop &amp;&amp; Save</source>
         <translation>Kırp ve Kaydet</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="527"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="387"/>
         <source>Cancel</source>
         <translation>İptal</translation>
     </message>
@@ -402,11 +420,13 @@
     <name>FVOptionsPopup</name>
     <message>
         <location filename="../../gui/folderview/fvoptionspopup.ui" line="32"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_fvoptionspopup.h" line="86"/>
         <source>Form</source>
         <translation>Biçim</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/fvoptionspopup.ui" line="53"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_fvoptionspopup.h" line="87"/>
         <source>View options</source>
         <translation>Görünüm düzeni</translation>
     </message>
@@ -415,56 +435,67 @@
     <name>FileReplaceDialog</name>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="14"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="130"/>
         <source>Dialog</source>
         <translation>İletişim kutusu</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="20"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="131"/>
         <source>title</source>
         <translation>başlık</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="33"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="132"/>
         <source>Source:</source>
         <translation>Kaynak:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="40"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="133"/>
         <source>src</source>
         <translation>kaynak</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="50"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="134"/>
         <source>&gt;&gt;&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="63"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="135"/>
         <source>Destination:</source>
         <translation>Hedef:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="70"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="136"/>
         <source>dst</source>
         <translation>hedef</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="111"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="137"/>
         <source>Apply to all</source>
         <translation>Hepsine uygula</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="118"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="138"/>
         <source>Yes</source>
         <translation>Evet</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="125"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="139"/>
         <source>No</source>
         <translation>Hayır</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="132"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="140"/>
         <source>Cancel</source>
         <translation>İptal</translation>
     </message>
@@ -473,77 +504,93 @@
     <name>FolderView</name>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="17"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="410"/>
         <source>Form</source>
         <translation>Biçim</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="145"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="411"/>
         <source>[path]</source>
         <translation>[yol]</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="195"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="413"/>
         <source>FolderViewSlider</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="242"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="416"/>
         <source>CheckableButton</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="274"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="426"/>
         <source>PanelComboBox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="281"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="418"/>
         <source>A - Z</source>
         <translation>A - Z</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="286"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="419"/>
         <source>Z - A</source>
         <translation>Z - A</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="291"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="420"/>
         <source>Size</source>
         <translation>Boyut</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="296"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="421"/>
         <source>Size (desc)</source>
         <translation>Boyut (azalan)</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="301"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="422"/>
         <source>Oldest</source>
         <translation>En eski</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="306"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="423"/>
         <source>Newest</source>
         <translation>En yeni</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="348"/>
         <location filename="../../gui/folderview/folderview.ui" line="373"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="429"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="432"/>
         <source>PanelButton</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="414"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="435"/>
         <source>PanelButtonRE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="476"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="438"/>
         <source>PlacesPanel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="532"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="440"/>
         <source>BOOKMARKS</source>
         <translation>HIZLI ERİŞİM</translation>
     </message>
@@ -551,11 +598,15 @@
         <location filename="../../gui/folderview/folderview.ui" line="551"/>
         <location filename="../../gui/folderview/folderview.ui" line="638"/>
         <location filename="../../gui/folderview/folderview.ui" line="657"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="442"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="446"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="449"/>
         <source>PlacesPanelButton</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="611"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="444"/>
         <source>FILESYSTEM</source>
         <translation>DOSYA SİSTEMİ</translation>
     </message>
@@ -564,11 +615,13 @@
     <name>ImageInfoOverlay</name>
     <message>
         <location filename="../../gui/overlays/imageinfooverlay.ui" line="65"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_imageinfooverlay.h" line="111"/>
         <source>OverlayHeaderWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/overlays/imageinfooverlay.ui" line="99"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_imageinfooverlay.h" line="113"/>
         <source>EXIF Tags</source>
         <translation>EXIF etiketleri</translation>
     </message>
@@ -584,35 +637,35 @@
 <context>
     <name>MW</name>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="565"/>
+        <location filename="../../gui/mainwindow.cpp" line="581"/>
         <source>Save File as...</source>
         <translation>Dosyayı farklı kaydet...</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="800"/>
+        <location filename="../../gui/mainwindow.cpp" line="816"/>
         <source>Folder view</source>
         <translation>Klasör görünümü</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="801"/>
-        <location filename="../../gui/mainwindow.cpp" line="802"/>
-        <location filename="../../gui/mainwindow.cpp" line="805"/>
-        <location filename="../../gui/mainwindow.cpp" line="806"/>
+        <location filename="../../gui/mainwindow.cpp" line="817"/>
+        <location filename="../../gui/mainwindow.cpp" line="818"/>
+        <location filename="../../gui/mainwindow.cpp" line="821"/>
+        <location filename="../../gui/mainwindow.cpp" line="822"/>
         <source>No file opened.</source>
         <translation>Açık dosya yok.</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="867"/>
+        <location filename="../../gui/mainwindow.cpp" line="883"/>
         <source>Fit Window</source>
         <translation>Pencereye sığdır</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="871"/>
+        <location filename="../../gui/mainwindow.cpp" line="887"/>
         <source>Fit Width</source>
         <translation>Genişliğe sığdır</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="875"/>
+        <location filename="../../gui/mainwindow.cpp" line="891"/>
         <source>Fit 1:1</source>
         <translation>Gerçek boyutta göster 1:1</translation>
     </message>
@@ -621,71 +674,85 @@
     <name>PrintDialog</name>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="20"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="304"/>
         <source>Print image</source>
         <translation>Görüntüyü yazdır</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="126"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="306"/>
         <source>Preview</source>
         <translation>Ön izleme</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="179"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="307"/>
         <source>Printer:</source>
         <translation>Yazıcı:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="189"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="308"/>
         <source>&lt;No printers found&gt;</source>
         <translation>&lt;Yazıcı bulunamadı&gt;</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="271"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="309"/>
         <source>Page orientation:</source>
         <translation>Sayfa yönü:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="297"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="310"/>
         <source>Portrait</source>
         <translation>Dikey</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="307"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="311"/>
         <source>Landscape</source>
         <translation>Yatay</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="348"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="312"/>
         <source>Color mode:</source>
         <translation>Renk düzeni:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="374"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="313"/>
         <source>Grayscale</source>
         <translation>Gri tonlamalı</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="384"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="314"/>
         <source>Color</source>
         <translation>Renkli</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="409"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="315"/>
         <source>Fit to page</source>
         <translation>Sayfaya sığdır</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="434"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="316"/>
         <source>Export PDF</source>
-        <translation>PDF'yi dışa aktar</translation>
+        <translation>PDF&apos;yi dışa aktar</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="454"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="317"/>
         <source>Print</source>
         <translation>Yazdır</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="464"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="318"/>
         <source>Cancel</source>
         <translation>İptal</translation>
     </message>
@@ -825,11 +892,14 @@
     <message>
         <location filename="../../gui/overlays/renameoverlay.ui" line="171"/>
         <location filename="../../gui/overlays/renameoverlay.ui" line="260"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_renameoverlay.h" line="213"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_renameoverlay.h" line="214"/>
         <source>Rename</source>
         <translation>Yeniden adlandır</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/renameoverlay.ui" line="273"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_renameoverlay.h" line="215"/>
         <source>Cancel</source>
         <translation>İptal</translation>
     </message>
@@ -838,151 +908,181 @@
     <name>ResizeDialog</name>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="32"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="358"/>
         <source>Resize</source>
         <translation>Yeniden boyutlandır</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="63"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="359"/>
         <source>By Percent:</source>
         <translation>Yüzde olarak:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="79"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="360"/>
         <source>By Absolute Size:</source>
         <translation>Kesin boyuta göre:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="98"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="361"/>
         <source>Percent:</source>
         <translation>Yüzde:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="119"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="362"/>
         <source>Width:</source>
         <translation>Genişlik:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="205"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="363"/>
         <source>Height:</source>
         <translation>Yükseklik:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="275"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="364"/>
         <source>Keep aspect ratio</source>
         <translation>En boy oranını koru</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="304"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="365"/>
         <source>Filter:</source>
         <translation>Filtre:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="330"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="366"/>
         <source>Nearest</source>
         <translation>Nearest</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="335"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="367"/>
         <source>Bilinear</source>
         <translation>Bilinear</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="340"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="368"/>
         <source>Bicubic</source>
         <translation>Bicubic</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="345"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="369"/>
         <source>Lanczos3</source>
         <translation>Lanczos3</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="358"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="371"/>
         <source>Common sizes:</source>
         <translation>Yaygın boyutlar:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="392"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="372"/>
         <source>Select:</source>
         <translation>Seç:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="397"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="373"/>
         <source>1366 x 768</source>
         <translation>1366 x 768</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="402"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="374"/>
         <source>1440 x 900</source>
         <translation>1440 x 900</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="407"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="375"/>
         <source>1440 x 1050</source>
         <translation>1440 x 1050</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="412"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="376"/>
         <source>1600 x 1200</source>
         <translation>1600 x 1200</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="417"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="377"/>
         <source>1920 x 1080 (FullHD)</source>
         <translation>1920 x 1080 (FullHD)</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="422"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="378"/>
         <source>1920 x 1200 (FullHD)</source>
         <translation>1920 x 1200 (FullHD)</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="427"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="379"/>
         <source>2560 x 1080</source>
         <translation>2560 x 1080</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="432"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="380"/>
         <source>2560 x 1440</source>
         <translation>2560 x 1440</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="437"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="381"/>
         <source>2560 x 1600</source>
         <translation>2560 x 1600</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="442"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="382"/>
         <source>3840 x 1600 (UW 4K)</source>
         <translation>3840 x 1600 (UW 4K)</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="447"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="383"/>
         <source>3840 x 2160 (UHD-1)</source>
         <translation>3840 x 2160 (UHD-1)</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="470"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="385"/>
         <source>Fit to desktop</source>
         <translation>Masaüstüne sığdır</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="489"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="386"/>
         <source>Fill desktop (expanding)</source>
         <translation>Masaüstünü doldur (genişleterek)</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="508"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="387"/>
         <source>Reset</source>
         <translation>Sıfırla</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="575"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="388"/>
         <source>OK</source>
         <translation>Tamam</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="594"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="389"/>
         <source>Cancel</source>
         <translation>İptal</translation>
     </message>
@@ -1034,21 +1134,25 @@
     <name>SaveConfirmOverlay</name>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="81"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="145"/>
         <source>Unsaved edits</source>
         <translation>Kaydedilmemiş değişiklikler</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="127"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="146"/>
         <source>Save</source>
         <translation>Kaydet</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="140"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="147"/>
         <source>Save as</source>
         <translation>Farklı kaydet</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="169"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="148"/>
         <source>Discard</source>
         <translation>Vazgeç</translation>
     </message>
@@ -1057,31 +1161,37 @@
     <name>ScriptEditorDialog</name>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="48"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="208"/>
         <source>Command:</source>
         <translation>Komut:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="84"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="209"/>
         <source>NOTE: make sure your .sh script has execute flag.</source>
         <translation>NOT: .sh betiğinizin çalıştırma izninin olduğundan emin olun.</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="91"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="210"/>
         <source>Name:</source>
         <translation>Ad:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="148"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="212"/>
         <source>Wait to finish</source>
         <translation>Bitirene kadar bekleyin</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="218"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="214"/>
         <source>Create</source>
         <translation>Oluştur</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="225"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="215"/>
         <source>Cancel</source>
         <translation>İptal</translation>
     </message>
@@ -1126,752 +1236,934 @@
     <name>SettingsDialog</name>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="47"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2892"/>
         <source>Preferences</source>
         <translation>Tercihler</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="53"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2894"/>
         <source>SettingsDialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="339"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2900"/>
         <source>General</source>
         <translation>Genel</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="415"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2901"/>
         <source>Language:</source>
         <translation>Dil:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="435"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2902"/>
         <source>Requires application restart</source>
         <translation>Uygulamanın yeniden başlatılması gerekir</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="473"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2903"/>
         <source>Open in fullscreen</source>
         <translation>Tam ekranda aç</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="480"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2904"/>
         <source>Start in folder view by default</source>
         <translation>Varsayılan olarak klasör görünümünde başlat</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="551"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2905"/>
         <source>User interface</source>
         <translation>Kullanıcı arayüzü</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="606"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2906"/>
         <source>Image info in window title</source>
         <translation>Dosya bilgisini pencere başlığında göster</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="626"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2907"/>
         <source>Auto-hide cursor</source>
         <translation>Fare imlecini otomatik gizle</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="633"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2909"/>
         <source>Turn this off if you are using a touchpad with libinput driver.</source>
         <translation>Libinput sürücüsüne sahip bir dokunmatik yüzey kullanıyorsanız, bunu kapatın.</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="636"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2911"/>
         <source>Enable smooth scrolling</source>
         <translation>Akıcı kaydırmayı etkinleştir</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="643"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2912"/>
         <source>Fullscreen info bar</source>
         <translation>Tam ekranda bilgi çubuğunu göster</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="656"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2913"/>
         <source>Status bar</source>
         <translation>Durum çubuğunu göster</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="689"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2914"/>
         <source>Zoom indicator:</source>
         <translation>Yakınlaştırma göstergesi:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="699"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2915"/>
         <source>On</source>
         <translation>Açık</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="706"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2916"/>
         <source>Off</source>
         <translation>Kapalı</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="713"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2917"/>
         <source>Auto</source>
         <translation>Otomatik</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="753"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2918"/>
         <source>Automatic window resize</source>
         <translation>Otomatik pencere boyutlandırma</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="763"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2919"/>
         <source>Match displayed content</source>
         <translation>Gösterilen içerikle eşleştir</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="799"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2920"/>
         <source>Screen area limit for auto resize:</source>
         <translation>Otomatik boyutlandırmada ekran alanı limiti:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="864"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2240"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2261"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2921"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2978"/>
         <source>xx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="962"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2925"/>
         <source>Thumbnail panel</source>
         <translation>Galeri paneli</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1018"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2926"/>
         <source>Crop previews</source>
         <translation>Ön izlemeleri kırp</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1031"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2927"/>
         <source>Pinned</source>
         <translation>Sabitlendi</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1050"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2928"/>
         <source>Disable in windowed mode</source>
         <translation>Pencere modunda devre dışı bırak</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1057"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2929"/>
         <source>Center selected image</source>
         <translation>Seçili görüntüyü ortala</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1109"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2930"/>
         <source>Extended</source>
         <translation>Ayrıntılı</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1119"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2931"/>
         <source>Previews only</source>
         <translation>Sadece ön izleme</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1126"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2932"/>
         <source>Display style:</source>
         <translation>Gösterim biçimi:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1139"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2933"/>
         <source>Show filename and resolution</source>
         <translation>Dosya adını ve çözünürlüğü göster</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1159"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2934"/>
         <source>Simple</source>
         <translation>Basit</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1183"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2935"/>
         <source>Preview size:</source>
         <translation>Ön izleme boyutu:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1258"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2936"/>
         <source>Position:</source>
         <translation>Konumu:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1266"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2064"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2085"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2937"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2972"/>
         <source>Top</source>
         <translation>Üstte</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1271"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2938"/>
         <source>Bottom</source>
         <translation>Altta</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1276"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2939"/>
         <source>Left</source>
         <translation>Solda</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1281"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2940"/>
         <source>Right</source>
         <translation>Sağda</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1374"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2942"/>
         <source>Folder navigation</source>
         <translation>Klasörde gezinme</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1400"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2943"/>
         <source>Stop</source>
         <translation>Durdur</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1410"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2944"/>
         <source>Loop folder</source>
         <translation>Klasörü döngüye al</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1417"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2945"/>
         <source>Go to the next folder</source>
         <translation>Sonraki klasöre git</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1424"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2946"/>
         <source>After reaching the end:</source>
         <translation>Sonuna ulaştıktan sonra:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1476"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2947"/>
         <source>Default sorting mode:</source>
         <translation>Varsayılan sıralama modu:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1493"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2948"/>
         <source>A - Z</source>
         <translation>A - Z</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1498"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2949"/>
         <source>Z - A</source>
         <translation>Z - A</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1503"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2950"/>
         <source>Size</source>
         <translation>Boyut</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1508"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2951"/>
         <source>Size (desc)</source>
         <translation>Boyut (azalan)</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1513"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2952"/>
         <source>Oldest</source>
         <translation>En eski</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1518"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2953"/>
         <source>Newest</source>
         <translation>En yeni</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1541"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2955"/>
         <source>Apply sorting to folders</source>
         <translation>Klasörlerde sıralamayı etkinleştir</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1609"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1555"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2956"/>
+        <source>Show hidden files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1623"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2957"/>
         <source>Video playback</source>
         <translation>Video oynatma</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1651"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1665"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2958"/>
         <source>Play sounds</source>
         <translation>Sesleri çal</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1720"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1734"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2959"/>
         <source>Slideshow</source>
         <translation>Slayt gösterisi</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1740"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1754"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2960"/>
         <source>Switch interval:</source>
         <translation>Slayt geçiş süresi:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1771"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1785"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2961"/>
         <source>ms</source>
         <translation>ms</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1803"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1817"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2962"/>
         <source>Loop slideshow</source>
         <translation>Slayt gösterisini döngüye al</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1900"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1914"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2963"/>
         <source>View</source>
         <translation>Görünüm</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1956"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1970"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2964"/>
         <source>Display options</source>
         <translation>Gösterim seçenekleri</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1980"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1994"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2965"/>
         <source>Image fit:</source>
         <translation>Görüntü yerleşimi:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1987"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2001"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2966"/>
         <source>Fit in window</source>
         <translation>Pencereye sığdır</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1997"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2011"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2967"/>
         <source>Stretch to width</source>
         <translation>Genişliğe göre esnet</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2004"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2018"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2968"/>
         <source>1:1</source>
         <translation>1:1</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="2025"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2969"/>
         <source>Fit in window (stretch)</source>
         <translation>Pencereye sığdır (uzat)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2026"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2047"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2970"/>
         <source>Keep fit mode when switching images</source>
         <translation>Sığdırma modunu görüntü geçişlerinde koru</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2057"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2078"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2971"/>
         <source>Focus in 1:1 mode:</source>
         <translation>1:1 modunda odak noktası:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2071"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2092"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2973"/>
         <source>Center</source>
         <translation>Merkez</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2078"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2099"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2974"/>
         <source>At cursor</source>
         <translation>İmleç konumuna</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2103"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2124"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2975"/>
         <source>Part of image that&apos;s focused after switching to 1:1</source>
         <translation>1:1 ölçeğinde odaklanan görüntü bölgesi</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2126"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2147"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2976"/>
         <source>Grid background on images with transparency</source>
         <translation>Saydam görüntüler için ızgara arka plan</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2163"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2184"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2977"/>
         <source>Expand images, up to:</source>
         <translation>En fazla şu orana kadar genişlet:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2271"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2292"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2979"/>
         <source>Images smaller than window will be zoomed in</source>
         <translation>Pencereden küçük görüntüler büyütülecek</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2323"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2344"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2980"/>
         <source>Zoom options</source>
         <translation>Yakınlaştırma seçenekleri</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2330"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2351"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2981"/>
         <source>Unlock minimum zoom</source>
         <translation>Minimum yakınlaştırmayı aç</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2340"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2361"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2982"/>
         <source>Always allow zooming below 100%</source>
-        <translation>Her zaman %100'ün altında yakınlaştırmaya izin ver</translation>
+        <translation>Her zaman %100&apos;ün altında yakınlaştırmaya izin ver</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2365"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2386"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2983"/>
         <source>Zoom step:</source>
         <translation>Yakınlaştırma kademesi:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2433"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2454"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2984"/>
         <source>[step]</source>
         <translation>[adım]</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2462"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2483"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2985"/>
         <source>Use fixed zoom levels:</source>
         <translation>Sabit yakınlaştırma seviyeleri kullan:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2506"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2527"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2986"/>
         <source>Load defaults</source>
         <translation>Varsayılanları yükle</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2574"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2595"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2987"/>
         <source>Scaling quality</source>
         <translation>Ölçekleme kalitesi</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2601"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2622"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2991"/>
         <source>Scaling filter:</source>
         <translation>Ölçekleme filtresi:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2633"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2654"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2992"/>
         <source>Nearest neighbor</source>
         <translation>Nearest neighbor</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2638"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2659"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2993"/>
         <source>Bilinear</source>
         <translation>Bilinear</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2680"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2701"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2999"/>
         <source>When unchecked, nearest neighbor algorithm will be used for upscaling.</source>
         <translation>İşaretlenmediğinde, büyütme işlemi için nearest neighbor algoritması kullanılır.</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2683"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2704"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3001"/>
         <source>Smooth upscaling</source>
         <translation>Pürüzsüz büyütme</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2702"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2723"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3002"/>
         <source>Smooth animated images</source>
         <translation>Animasyonları yumuşat</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2781"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2802"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3003"/>
         <source>Theme</source>
         <translation>Tema</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2840"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2861"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3004"/>
         <source>Load preset:</source>
         <translation>Ön ayarı yükle:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2853"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2857"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2874"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2878"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3005"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3010"/>
         <source>Black</source>
         <translation>Siyah</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2862"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2883"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3006"/>
         <source>Dark</source>
         <translation>Koyu</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2867"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2888"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3007"/>
         <source>Dark Blue</source>
         <translation>Koyu mavi</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2872"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2893"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3008"/>
         <source>Light</source>
         <translation>Açık</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2896"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2917"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3011"/>
         <source>Use system colors</source>
         <translation>Sistem renklerini kullan</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2906"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2927"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3012"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;modify&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;değiştir&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3132"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3153"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3015"/>
         <source>Accent</source>
         <translation>Vurgu rengi</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3139"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3160"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3016"/>
         <source>Background</source>
         <translation>Arka plan</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3146"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3167"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3017"/>
         <source>Background (fullscreen mode)</source>
         <translation>Arka plan (Tam ekran modu)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3184"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3205"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3019"/>
         <source>Text</source>
         <translation>Metin rengi</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3191"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3212"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3020"/>
         <source>Icons</source>
         <translation>İkonlar</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3291"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3312"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3024"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="62"/>
         <source>Overlay background</source>
         <translation>Yer paylaşımlı arka plan</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3329"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3350"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3026"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="60"/>
         <source>Widget background</source>
         <translation>Widget arka planı</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3336"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3357"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3027"/>
         <source>Folder view top panel</source>
         <translation>Klasör görünümü üst paneli</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3343"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3364"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3028"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="61"/>
         <source>Widget border</source>
         <translation>Widget kenarlığı</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3412"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3433"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3031"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="63"/>
         <source>Overlay text</source>
         <translation>Yer paylaşımlı metin</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3450"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3471"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3033"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="64"/>
         <source>Scrollbars</source>
         <translation>Kaydırma çubukları</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3457"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3478"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3034"/>
         <source>Folder view background</source>
         <translation>Klasör görünümü arka planı</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3528"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3549"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3035"/>
         <source>Other window tweaks</source>
         <translation>Diğer pencere ayarlamaları</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3543"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3564"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3036"/>
         <source>Window opacity:</source>
         <translation>Pencere saydamlığı:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3596"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3617"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3037"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3621"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3642"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3038"/>
         <source>Background blur (KDE)</source>
         <translation>Arka plan bulanıklığı (KDE)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3673"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3694"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3039"/>
         <source>Controls</source>
         <translation>Kontroller</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3734"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4073"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3755"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4200"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3040"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3063"/>
         <source>Add</source>
         <translation>Ekle</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3741"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4080"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3762"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4207"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3041"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3064"/>
         <source>Edit</source>
         <translation>Düzenle</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3754"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4087"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3775"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4214"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3042"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3065"/>
         <source>Remove</source>
         <translation>Kaldır</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3783"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3804"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3043"/>
         <source>Reset to defaults</source>
         <translation>Varsayılan ayarlara sıfırla</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3817"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3838"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3045"/>
         <source>Action</source>
         <translation>İşlem</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3822"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3843"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3047"/>
         <source>Shortcut</source>
         <translation>Kısayol</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3874"/>
-        <source>Mouse &amp; touchpad</source>
-        <translation>Fare ve dokunmatik yüzey</translation>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3898"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3048"/>
+        <source>Switch image by clicking window edges</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3895"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3905"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3049"/>
+        <source>Visible edges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mouse &amp; touchpad</source>
+        <translation type="vanished">Fare ve dokunmatik yüzey</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3935"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3050"/>
         <source>Scroll image with:</source>
         <translation>Görüntüyü kaydırmak için:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3903"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3943"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3051"/>
         <source>None</source>
         <translation>Hiçbiri</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3908"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3948"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3052"/>
         <source>Touchpad</source>
         <translation>Dokunmatik yüzey</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3913"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3953"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3053"/>
         <source>Touchpad &amp; Mouse Wheel</source>
         <translation>Dokunmatik yüzey ve fare tekerleği</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3939"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3979"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3055"/>
         <source>Note: you can also zoom by holding RMB and moving the mouse</source>
         <translation>Not: Sağ fare tuşuna basılı tutup fareyi hareket ettirerek de yakınlaştırabilirsiniz</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3953"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4007"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3056"/>
+        <source>Mouse scrolling speed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4051"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3057"/>
+        <source>[x]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4080"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3058"/>
         <source>Trackpad detection</source>
         <translation>Dokunmatik yüzey algılama</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3963"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4090"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3059"/>
         <source>Disable if you have issues with mouse scrolling</source>
         <translation>Fare kaydırma ile ilgili sorun yaşıyorsanız devre dışı bırakın.</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3995"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4122"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3060"/>
         <source>Scripts</source>
         <translation>Komut dosyaları</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4051"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4178"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3061"/>
         <source>Note: these will appear in &quot;Open with&quot; menu.</source>
         <translation>Not: Bunlar “Birlikte aç” menüsünde görünecektir.</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4061"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4188"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3062"/>
         <source>Also, you can assign shortcuts to scripts (in &quot;Controls&quot; section).</source>
-        <translation>Ayrıca komut dosyalarına kısayollar atayabilirsiniz ("Kontroller" bölümünde).</translation>
+        <translation>Ayrıca komut dosyalarına kısayollar atayabilirsiniz (&quot;Kontroller&quot; bölümünde).</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4170"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4297"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3066"/>
         <source>Advanced</source>
         <translation>Gelişmiş</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4227"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4354"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3068"/>
         <source>Preload the next/previous image. Results in a much faster image switching (at the expense of wasting more RAM).</source>
         <translation>Sonraki/önceki görüntüyü önceden yükleyin. Bu çok daha hızlı görüntü geçişi sağlar (ancak daha fazla RAM harcanır).</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4230"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4357"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3070"/>
         <source>Use preloader (recommended)</source>
         <translation>Ön yükleyiciyi kullanın (önerilir)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4240"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4367"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3071"/>
         <source>Load adjacent images in background</source>
         <translation>Arka planda bitişik görüntüleri yükle</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4268"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4395"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3072"/>
         <source>Thumbnailer thread count:</source>
         <translation>Küçük resim oluşturucu iş parçacığı sayısı:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4306"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4433"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3073"/>
         <source>2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">2</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4337"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4464"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3077"/>
         <source>Use thumbnail cache (recommended)</source>
         <translation>Küçük resim önbelleğini kullan (önerilir)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4344"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4471"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3078"/>
         <source>Unload off-screen thumbnails</source>
         <translation>Ekranda olmayan küçük resimleri kaldır</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4354"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4481"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3079"/>
         <source>Dynamically unload items to save memory</source>
         <translation>Bellek tasarrufu için öğeleri dinamik olarak kaldır</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4368"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4495"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3080"/>
         <source>Show save overlay when editing images</source>
         <translation>Görüntü düzenleme sırasında kaydetme ekranını göster</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4383"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4510"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3081"/>
         <source>JPEG save quality:</source>
         <translation>JPEG kaydetme kalitesi:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4427"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4554"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3082"/>
         <source>q</source>
         <translation>kalite</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4456"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4583"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3083"/>
         <source>Confirm moving to trash</source>
         <translation>Çöp kutusuna taşırken onay iste</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4468"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4595"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3084"/>
         <source>Confirm file delete (!)</source>
         <translation>Dosyayı silmeyi onaylayın (!)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4482"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4609"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3085"/>
         <source>JXL animation support (experimental)</source>
         <translation>JXL animasyon desteği (deneysel)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4510"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4637"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3086"/>
         <source>Memory allocation limit per image, MB:</source>
         <translation>Her bir görüntü için bellek sınırlaması, MB:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4571"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4698"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3087"/>
         <source>Mpv binary:</source>
         <translation>Mpv program dosyası:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4612"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4739"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3088"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4706"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4833"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3089"/>
         <source>About qimgv</source>
         <translation>qimgv hakkında</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4757"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4884"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3090"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -1910,17 +2202,20 @@ li.checked::marker { content: &quot;\2612&quot;; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:10pt;&quot;&gt;Sorun bildirmek / özellik talebi için &lt;/span&gt;&lt;a href=&quot;https://github.com/easymodo/qimgv/issues&quot;&gt;&lt;span style=&quot; font-family:&apos;Droid Sans&apos;; font-size:10pt; text-decoration: underline; color:#007af4;&quot;&gt;here&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4850"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4977"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3112"/>
         <source>OK</source>
         <translation>Tamam</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4857"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4984"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3113"/>
         <source>Apply</source>
         <translation>Uygula</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4864"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4991"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3114"/>
         <source>Cancel</source>
         <translation>İptal</translation>
     </message>
@@ -1960,40 +2255,50 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>Metin rengi</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.cpp" line="569"/>
+        <location filename="../../gui/dialogs/settingsdialog.cpp" line="590"/>
         <source>Edit shortcut</source>
         <translation>Kısayolu düzenle</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.cpp" line="620"/>
+        <location filename="../../gui/dialogs/settingsdialog.cpp" line="641"/>
         <source>Navigate to mpv binary</source>
         <translation>mpv program dosyasına git</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.cpp" line="649"/>
+        <source>Maximum</source>
+        <translation>Maksimum</translation>
     </message>
 </context>
 <context>
     <name>ShortcutCreatorDialog</name>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="14"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="148"/>
         <source>New shortcut</source>
         <translation>Yeni kısayol</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="34"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="149"/>
         <source>Action:</source>
         <translation>İşlem:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="73"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="150"/>
         <source>Script:</source>
         <translation>Komut dosyası:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="117"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="151"/>
         <source>Shortcut:</source>
         <translation>Kısayol:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="124"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="152"/>
         <source>[Enter shortcut]</source>
         <translation>[Kısayolu girin]</translation>
     </message>
@@ -2001,32 +2306,32 @@ li.checked::marker { content: &quot;\2612&quot;; }
 <context>
     <name>main</name>
     <message>
-        <location filename="../../main.cpp" line="133"/>
+        <location filename="../../main.cpp" line="126"/>
         <source>File or directory path.</source>
         <translation>Dosya veya dizin yolu.</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="136"/>
+        <location filename="../../main.cpp" line="129"/>
         <source>Generate all thumbnails for directory.</source>
         <translation>Dizindeki tüm küçük resimleri oluştur.</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="137"/>
+        <location filename="../../main.cpp" line="130"/>
         <source>directory-path</source>
         <translation>dizin-yolu</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="139"/>
+        <location filename="../../main.cpp" line="132"/>
         <source>Thumbnail size. Current size is used if not specified.</source>
         <translation>Küçük resim boyutu. Belirtilmediği takdirde şu anki boyut kullanılır.</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="140"/>
+        <location filename="../../main.cpp" line="133"/>
         <source>thumbnail-size</source>
         <translation>küçük resim-boyutu</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="142"/>
+        <location filename="../../main.cpp" line="135"/>
         <source>Show build options.</source>
         <translation>Derleme seçeneklerini göster.</translation>
     </message>

--- a/qimgv/res/translations/uk_UA.ts
+++ b/qimgv/res/translations/uk_UA.ts
@@ -5,11 +5,13 @@
     <name>ChangelogWindow</name>
     <message>
         <location filename="../../gui/overlays/changelogwindow.ui" line="154"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_changelogwindow.h" line="137"/>
         <source>Close, never show changelogs</source>
         <translation>Закрити, більше не показувати</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/changelogwindow.ui" line="170"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_changelogwindow.h" line="138"/>
         <source>Close</source>
         <translation>Закрити</translation>
     </message>
@@ -17,62 +19,63 @@
 <context>
     <name>ContextMenu</name>
     <message>
-        <location filename="../../gui/contextmenu.ui" line="229"/>
+        <location filename="../../gui/contextmenu.ui" line="236"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_contextmenu.h" line="449"/>
         <source>Edit</source>
         <translation>Редагувати</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="55"/>
+        <location filename="../../gui/contextmenu.cpp" line="58"/>
         <source>Print</source>
         <translation>Друк</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="59"/>
+        <location filename="../../gui/contextmenu.cpp" line="62"/>
         <source>Quick copy</source>
         <translation>Шв. копіювання</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="63"/>
+        <location filename="../../gui/contextmenu.cpp" line="66"/>
         <source>Quick move</source>
         <translation>Шв. переміщення</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="67"/>
+        <location filename="../../gui/contextmenu.cpp" line="70"/>
         <source>Move to trash</source>
         <translation>Помістити в корзину</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="72"/>
+        <location filename="../../gui/contextmenu.cpp" line="75"/>
         <source>Open</source>
         <translation>Відкрити</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="77"/>
+        <location filename="../../gui/contextmenu.cpp" line="80"/>
         <source>Folder View</source>
         <translation>Перегляд теки</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="82"/>
+        <location filename="../../gui/contextmenu.cpp" line="85"/>
         <source>Settings</source>
         <translation>Налаштування</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="85"/>
+        <location filename="../../gui/contextmenu.cpp" line="88"/>
         <source>Open with...</source>
         <translation>Відкрити в...</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="91"/>
+        <location filename="../../gui/contextmenu.cpp" line="94"/>
         <source>Show in folder</source>
         <translation>Показати в теці</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="99"/>
+        <location filename="../../gui/contextmenu.cpp" line="102"/>
         <source>Back</source>
         <translation>Назад</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="102"/>
+        <location filename="../../gui/contextmenu.cpp" line="105"/>
         <source>Configure menu</source>
         <translation>Налаштувати меню</translation>
     </message>
@@ -94,228 +97,228 @@
 <context>
     <name>Core</name>
     <message>
-        <location filename="../../core.cpp" line="255"/>
+        <location filename="../../core.cpp" line="258"/>
         <source>Updated: </source>
         <translation>Оновлено: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="261"/>
-        <source>Welcome to </source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../../core.cpp" line="261"/>
+        <location filename="../../core.cpp" line="264"/>
         <source> version </source>
         <translation> версія </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="268"/>
+        <location filename="../../core.cpp" line="264"/>
+        <source>Welcome to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../core.cpp" line="271"/>
         <source>Shuffle mode: OFF</source>
         <translation>Режим перемішування: Вимкнено</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="271"/>
+        <location filename="../../core.cpp" line="274"/>
         <source>Shuffle mode: ON</source>
         <translation>Режим перемішування: Увімкнено</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="280"/>
+        <location filename="../../core.cpp" line="283"/>
         <source>Slideshow: OFF</source>
         <translation>Слайд-шоу: Вимкнено</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="284"/>
+        <location filename="../../core.cpp" line="287"/>
         <source>Slideshow: ON</source>
         <translation>Слайд-шоу: Увімкнено</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="355"/>
+        <location filename="../../core.cpp" line="358"/>
         <source>Delete </source>
         <translation>Видалити </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="355"/>
+        <location filename="../../core.cpp" line="358"/>
         <source> items permanently?</source>
         <translation> елементів остаточно?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="357"/>
+        <location filename="../../core.cpp" line="360"/>
         <source>Delete item permanently?</source>
         <translation>Видалити елемент остаточно?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="358"/>
+        <location filename="../../core.cpp" line="361"/>
         <source>Delete permanently</source>
         <translation>Видалити остаточно</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="374"/>
+        <location filename="../../core.cpp" line="377"/>
         <source>File removed</source>
         <translation>Файл видалено</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="378"/>
+        <location filename="../../core.cpp" line="381"/>
         <source>Removed: </source>
         <translation>Видалено: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="378"/>
-        <location filename="../../core.cpp" line="408"/>
+        <location filename="../../core.cpp" line="381"/>
+        <location filename="../../core.cpp" line="411"/>
         <source> files</source>
         <translation> файлів</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="389"/>
+        <location filename="../../core.cpp" line="392"/>
         <source>Move </source>
         <translation>Помістити </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="389"/>
+        <location filename="../../core.cpp" line="392"/>
         <source> items to trash?</source>
         <translation> елементів до кошику?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="391"/>
+        <location filename="../../core.cpp" line="394"/>
         <source>Move item to trash?</source>
         <translation>Помістити елемент до кошику?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="392"/>
+        <location filename="../../core.cpp" line="395"/>
         <source>Move to trash</source>
         <translation>Помістити в кошик</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="404"/>
+        <location filename="../../core.cpp" line="407"/>
         <source>Moved to trash</source>
         <translation>Переміщено в кошик</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="408"/>
+        <location filename="../../core.cpp" line="411"/>
         <source>Moved to trash: </source>
         <translation>Переміщено в кошик: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="463"/>
+        <location filename="../../core.cpp" line="466"/>
         <source>File copied</source>
         <translation>Файл скопійовано</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="470"/>
+        <location filename="../../core.cpp" line="473"/>
         <source>Path copied</source>
         <translation>Шлях скопійовано</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="644"/>
-        <location filename="../../core.cpp" line="918"/>
-        <location filename="../../core.cpp" line="939"/>
+        <location filename="../../core.cpp" line="647"/>
+        <location filename="../../core.cpp" line="928"/>
+        <location filename="../../core.cpp" line="949"/>
         <source>File exists</source>
         <translation>Файл існує</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="644"/>
+        <location filename="../../core.cpp" line="647"/>
         <source>Overwrite file?</source>
         <translation>Перезаписати файл?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="812"/>
-        <location filename="../../core.cpp" line="880"/>
+        <location filename="../../core.cpp" line="822"/>
+        <location filename="../../core.cpp" line="890"/>
         <source>Could not create directory </source>
         <translation>Не вдалося створити директорію </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="916"/>
+        <location filename="../../core.cpp" line="926"/>
         <source>File moved.</source>
         <translation>Файл переміщено.</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="918"/>
-        <location filename="../../core.cpp" line="939"/>
+        <location filename="../../core.cpp" line="928"/>
+        <location filename="../../core.cpp" line="949"/>
         <source>Destination file exists. Overwrite?</source>
         <translation>Файл існує. Перезаписати?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="937"/>
+        <location filename="../../core.cpp" line="947"/>
         <source>File copied.</source>
         <translation>Файл скопійовано.</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="984"/>
+        <location filename="../../core.cpp" line="994"/>
         <source>Perform action &quot;</source>
         <translation>Виконати дію &quot;</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="984"/>
+        <location filename="../../core.cpp" line="994"/>
         <source>Changes will be saved immediately.</source>
         <translation>Зміни будуть збережені негайно.</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1002"/>
+        <location filename="../../core.cpp" line="1012"/>
         <source>Flip horizontal</source>
         <translation>Перевернути горизонтально</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1006"/>
+        <location filename="../../core.cpp" line="1016"/>
         <source>Flip vertical</source>
         <translation>Перевернути вертикально</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1010"/>
+        <location filename="../../core.cpp" line="1020"/>
         <source>Rotate</source>
         <translation>Повернути</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1014"/>
+        <location filename="../../core.cpp" line="1024"/>
         <source>Resize</source>
         <translation>Змінити розмір</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1020"/>
-        <location filename="../../core.cpp" line="1026"/>
+        <location filename="../../core.cpp" line="1030"/>
+        <location filename="../../core.cpp" line="1036"/>
         <source>Crop</source>
         <translation>Обрізати</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1058"/>
+        <location filename="../../core.cpp" line="1068"/>
         <source>File saved</source>
         <translation>Файл збережено</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1061"/>
+        <location filename="../../core.cpp" line="1071"/>
         <source>Could not save file</source>
         <translation>Не вдалос зберегти файл</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1171"/>
+        <location filename="../../core.cpp" line="1181"/>
         <source>Could not open image</source>
         <translation>Не вдалося відкрити зображення</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1175"/>
+        <location filename="../../core.cpp" line="1185"/>
         <source>Can only print static images</source>
         <translation>Можливий друк лише статичних зображень</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1226"/>
+        <location filename="../../core.cpp" line="1236"/>
         <source>Could not open path: </source>
         <translation>Не вдалося відкрити шлях: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1260"/>
+        <location filename="../../core.cpp" line="1270"/>
         <source>Could not load folder: </source>
         <translation>Не вдалося завантажити теку: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1413"/>
+        <location filename="../../core.cpp" line="1423"/>
         <source>End of directory.</source>
         <translation>Кінець директорії.</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1452"/>
+        <location filename="../../core.cpp" line="1462"/>
         <source>Load failed: </source>
         <translation>Завантаження не вдалося: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1496"/>
+        <location filename="../../core.cpp" line="1506"/>
         <source>Error: could not load image.</source>
         <translation>Помилка: не вдалося завантажити зображення.</translation>
     </message>
@@ -324,76 +327,91 @@
     <name>CropPanel</name>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="107"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="370"/>
         <source>Selection</source>
         <translation>Виділення</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="125"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="371"/>
         <source>Width</source>
         <translation>Ширина</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="161"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="372"/>
         <source>Height</source>
         <translation>Висота</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="322"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="374"/>
         <source>Aspect Ratio</source>
         <translation>Співвідношення сторін</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="336"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="375"/>
         <source>Free</source>
         <translation>Вільне</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="341"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="376"/>
         <source>Custom</source>
         <translation>Користувацьке</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="346"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="377"/>
         <source>Current Image</source>
         <translation>З поточного зображення</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="351"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="378"/>
         <source>This Screen</source>
         <translation>З поточного екрану</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="356"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="379"/>
         <source>1:1</source>
         <translation>1:1</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="361"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="380"/>
         <source>4:3</source>
         <translation>4:3</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="366"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="381"/>
         <source>16:9</source>
         <translation>16:9</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="371"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="382"/>
         <source>16:10</source>
         <translation>16:10</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="499"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="385"/>
         <source>Crop</source>
         <translation>Обрізати</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="512"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="386"/>
         <source>Crop &amp;&amp; Save</source>
         <translation>Обрізати &amp;&amp; зберегти</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="527"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="387"/>
         <source>Cancel</source>
         <translation>Відмінити</translation>
     </message>
@@ -402,11 +420,13 @@
     <name>FVOptionsPopup</name>
     <message>
         <location filename="../../gui/folderview/fvoptionspopup.ui" line="32"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_fvoptionspopup.h" line="86"/>
         <source>Form</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/fvoptionspopup.ui" line="53"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_fvoptionspopup.h" line="87"/>
         <source>View options</source>
         <translation>Параметри</translation>
     </message>
@@ -415,56 +435,67 @@
     <name>FileReplaceDialog</name>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="14"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="130"/>
         <source>Dialog</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="20"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="131"/>
         <source>title</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="33"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="132"/>
         <source>Source:</source>
         <translation>Джерело:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="40"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="133"/>
         <source>src</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="50"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="134"/>
         <source>&gt;&gt;&gt;</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="63"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="135"/>
         <source>Destination:</source>
         <translation>Призначення:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="70"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="136"/>
         <source>dst</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="111"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="137"/>
         <source>Apply to all</source>
         <translation>Застосувати для всіх</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="118"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="138"/>
         <source>Yes</source>
         <translation>Так</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="125"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="139"/>
         <source>No</source>
         <translation>Ні</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="132"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="140"/>
         <source>Cancel</source>
         <translation>Відмінити</translation>
     </message>
@@ -473,77 +504,93 @@
     <name>FolderView</name>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="17"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="410"/>
         <source>Form</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="145"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="411"/>
         <source>[path]</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="195"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="413"/>
         <source>FolderViewSlider</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="242"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="416"/>
         <source>CheckableButton</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="274"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="426"/>
         <source>PanelComboBox</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="281"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="418"/>
         <source>A - Z</source>
         <translation>А - Я</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="286"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="419"/>
         <source>Z - A</source>
         <translation>Я - А</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="291"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="420"/>
         <source>Size</source>
         <translation>Розмір</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="296"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="421"/>
         <source>Size (desc)</source>
         <translation>Розмір (зв.)</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="301"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="422"/>
         <source>Oldest</source>
         <translation>Найстаріші</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="306"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="423"/>
         <source>Newest</source>
         <translation>Найновіші</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="348"/>
         <location filename="../../gui/folderview/folderview.ui" line="373"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="429"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="432"/>
         <source>PanelButton</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="414"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="435"/>
         <source>PanelButtonRE</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="476"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="438"/>
         <source>PlacesPanel</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="532"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="440"/>
         <source>BOOKMARKS</source>
         <translation>ЗАКЛАДКИ</translation>
     </message>
@@ -551,11 +598,15 @@
         <location filename="../../gui/folderview/folderview.ui" line="551"/>
         <location filename="../../gui/folderview/folderview.ui" line="638"/>
         <location filename="../../gui/folderview/folderview.ui" line="657"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="442"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="446"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="449"/>
         <source>PlacesPanelButton</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="611"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="444"/>
         <source>FILESYSTEM</source>
         <translation>ФАЙЛОВА СИСТЕМА</translation>
     </message>
@@ -564,11 +615,13 @@
     <name>ImageInfoOverlay</name>
     <message>
         <location filename="../../gui/overlays/imageinfooverlay.ui" line="65"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_imageinfooverlay.h" line="111"/>
         <source>OverlayHeaderWidget</source>
         <translation>OverlayHeaderWidget</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/imageinfooverlay.ui" line="99"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_imageinfooverlay.h" line="113"/>
         <source>EXIF Tags</source>
         <translation>Теги EXIF</translation>
     </message>
@@ -584,35 +637,35 @@
 <context>
     <name>MW</name>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="536"/>
+        <location filename="../../gui/mainwindow.cpp" line="581"/>
         <source>Save File as...</source>
         <translation>Зберегти файл як...</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="771"/>
+        <location filename="../../gui/mainwindow.cpp" line="816"/>
         <source>Folder view</source>
         <translation>Галерея</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="772"/>
-        <location filename="../../gui/mainwindow.cpp" line="773"/>
-        <location filename="../../gui/mainwindow.cpp" line="776"/>
-        <location filename="../../gui/mainwindow.cpp" line="777"/>
+        <location filename="../../gui/mainwindow.cpp" line="817"/>
+        <location filename="../../gui/mainwindow.cpp" line="818"/>
+        <location filename="../../gui/mainwindow.cpp" line="821"/>
+        <location filename="../../gui/mainwindow.cpp" line="822"/>
         <source>No file opened.</source>
         <translation>Файл не відкрито.</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="838"/>
+        <location filename="../../gui/mainwindow.cpp" line="883"/>
         <source>Fit Window</source>
         <translation>Вписати у вікно</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="842"/>
+        <location filename="../../gui/mainwindow.cpp" line="887"/>
         <source>Fit Width</source>
         <translation>Розтягнути по ширині</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="846"/>
+        <location filename="../../gui/mainwindow.cpp" line="891"/>
         <source>Fit 1:1</source>
         <translation>Режим 1:1</translation>
     </message>
@@ -621,71 +674,85 @@
     <name>PrintDialog</name>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="20"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="304"/>
         <source>Print image</source>
         <translation>Друк зображення</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="126"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="306"/>
         <source>Preview</source>
         <translation>Превью</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="179"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="307"/>
         <source>Printer:</source>
         <translation>Принтер:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="189"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="308"/>
         <source>&lt;No printers found&gt;</source>
         <translation>&lt;Принтери не знайдені&gt;</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="271"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="309"/>
         <source>Page orientation:</source>
         <translation>Орієнтація сторінки:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="297"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="310"/>
         <source>Portrait</source>
         <translation>Портретний</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="307"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="311"/>
         <source>Landscape</source>
         <translation>Ландшафтний</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="348"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="312"/>
         <source>Color mode:</source>
         <translation>Режим кольорів:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="374"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="313"/>
         <source>Grayscale</source>
         <translation>Градації сірого</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="384"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="314"/>
         <source>Color</source>
         <translation>Кольоровий</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="409"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="315"/>
         <source>Fit to page</source>
         <translation>Підігнати під сторінку</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="434"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="316"/>
         <source>Export PDF</source>
         <translation>Зберегти в PDF</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="454"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="317"/>
         <source>Print</source>
         <translation>Друкувати</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="464"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="318"/>
         <source>Cancel</source>
         <translation>Відмінити</translation>
     </message>
@@ -812,7 +879,7 @@
     <message>
         <location filename="../../utils/fileoperations.cpp" line="59"/>
         <source>Nothing to do.</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../utils/fileoperations.cpp" line="61"/>
@@ -825,11 +892,14 @@
     <message>
         <location filename="../../gui/overlays/renameoverlay.ui" line="171"/>
         <location filename="../../gui/overlays/renameoverlay.ui" line="260"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_renameoverlay.h" line="213"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_renameoverlay.h" line="214"/>
         <source>Rename</source>
         <translation>Перейменувати</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/renameoverlay.ui" line="273"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_renameoverlay.h" line="215"/>
         <source>Cancel</source>
         <translation>Відмінити</translation>
     </message>
@@ -838,151 +908,181 @@
     <name>ResizeDialog</name>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="32"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="358"/>
         <source>Resize</source>
         <translation>Змінити розмір</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="63"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="359"/>
         <source>By Percent:</source>
         <translation>За відсотком:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="79"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="360"/>
         <source>By Absolute Size:</source>
         <translation>За абсолютним розміром:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="98"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="361"/>
         <source>Percent:</source>
         <translation>Відсоток:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="119"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="362"/>
         <source>Width:</source>
         <translation>Ширина:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="205"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="363"/>
         <source>Height:</source>
         <translation>Висота:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="275"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="364"/>
         <source>Keep aspect ratio</source>
         <translation>Зберегти співвідношення сторін</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="304"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="365"/>
         <source>Filter:</source>
         <translation>Фільтр:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="330"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="366"/>
         <source>Nearest</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="335"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="367"/>
         <source>Bilinear</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="340"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="368"/>
         <source>Bicubic</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="345"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="369"/>
         <source>Lanczos3</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="358"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="371"/>
         <source>Common sizes:</source>
         <translation>Поширені розміри:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="392"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="372"/>
         <source>Select:</source>
         <translation>Оберіть:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="397"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="373"/>
         <source>1366 x 768</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="402"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="374"/>
         <source>1440 x 900</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="407"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="375"/>
         <source>1440 x 1050</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="412"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="376"/>
         <source>1600 x 1200</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="417"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="377"/>
         <source>1920 x 1080 (FullHD)</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="422"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="378"/>
         <source>1920 x 1200 (FullHD)</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="427"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="379"/>
         <source>2560 x 1080</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="432"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="380"/>
         <source>2560 x 1440</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="437"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="381"/>
         <source>2560 x 1600</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="442"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="382"/>
         <source>3840 x 1600 (UW 4K)</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="447"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="383"/>
         <source>3840 x 2160 (UHD-1)</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="470"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="385"/>
         <source>Fit to desktop</source>
         <translation>Підігнати до роб. столу</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="489"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="386"/>
         <source>Fill desktop (expanding)</source>
         <translation>Заповнити роб. стіл</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="508"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="387"/>
         <source>Reset</source>
         <translation>Скинути</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="575"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="388"/>
         <source>OK</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="594"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="389"/>
         <source>Cancel</source>
         <translation>Відмінити</translation>
     </message>
@@ -1034,21 +1134,25 @@
     <name>SaveConfirmOverlay</name>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="81"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="145"/>
         <source>Unsaved edits</source>
         <translation>Не збережені зміни</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="127"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="146"/>
         <source>Save</source>
         <translation>Зберегти</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="140"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="147"/>
         <source>Save as</source>
         <translation>Зберегти як</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="169"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="148"/>
         <source>Discard</source>
         <translation>Скинути</translation>
     </message>
@@ -1057,31 +1161,37 @@
     <name>ScriptEditorDialog</name>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="48"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="208"/>
         <source>Command:</source>
         <translation>Команда:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="84"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="209"/>
         <source>NOTE: make sure your .sh script has execute flag.</source>
         <translation>Прим.: переконайтеся що ваш .sh файл є виконуваним.</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="91"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="210"/>
         <source>Name:</source>
         <translation>Ім&apos;я:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="148"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="212"/>
         <source>Wait to finish</source>
         <translation>Чекати до кінця виконання</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="218"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="214"/>
         <source>Create</source>
         <translation>Створити</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="225"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="215"/>
         <source>Cancel</source>
         <translation>Відмінити</translation>
     </message>
@@ -1126,478 +1236,605 @@
     <name>SettingsDialog</name>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="47"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2892"/>
         <source>Preferences</source>
         <translation>Налаштування</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="53"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2894"/>
         <source>SettingsDialog</source>
         <translation>SettingsDialog</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="339"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2900"/>
         <source>General</source>
         <translation>Загальні</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3666"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3694"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3039"/>
         <source>Controls</source>
         <translation>Керування</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3964"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4122"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3060"/>
         <source>Scripts</source>
         <translation>Скріпти</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4139"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4297"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3066"/>
         <source>Advanced</source>
         <translation>Продвинуті</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="415"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2901"/>
         <source>Language:</source>
         <translation>Мова:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="473"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2903"/>
         <source>Open in fullscreen</source>
         <translation>Відкривати в повноекранному режимі</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="480"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2904"/>
         <source>Start in folder view by default</source>
         <translation>Відкривати в галереї за замовчуванням</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="864"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2233"/>
-        <source>xx</source>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="626"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2907"/>
         <source>Auto-hide cursor</source>
         <translation>Приховувати курсор</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1973"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1994"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2965"/>
         <source>Image fit:</source>
         <translation>Підігнати зображення:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1990"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2011"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2967"/>
         <source>Stretch to width</source>
         <translation>Розтягнути по ширині</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1997"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2018"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2968"/>
         <source>1:1</source>
         <translation>1:1</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1980"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2001"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2966"/>
         <source>Fit in window</source>
         <translation>Вписати у вікно</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1266"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2057"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2085"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2937"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2972"/>
         <source>Top</source>
         <translation>Зверху</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1400"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2943"/>
         <source>Stop</source>
         <translation>Зупинитись</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2064"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2092"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2973"/>
         <source>Center</source>
         <translation>По центру</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2071"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2099"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2974"/>
         <source>At cursor</source>
         <translation>На курсор</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2050"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2078"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2971"/>
         <source>Focus in 1:1 mode:</source>
         <translation>Фокус в режимі 1:1:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1602"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1623"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2957"/>
         <source>Video playback</source>
         <translation>Відео програвач</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1644"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1665"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2958"/>
         <source>Play sounds</source>
         <translation>Програвати аудіо</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="962"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2925"/>
         <source>Thumbnail panel</source>
         <translation>Панель превью</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1050"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2928"/>
         <source>Disable in windowed mode</source>
         <translation>Вимкнути у віконному режимі</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1018"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2926"/>
         <source>Crop previews</source>
         <translation>Обрізати превью</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1057"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2929"/>
         <source>Center selected image</source>
         <translation>Центрувати на поточне зображення</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1258"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2936"/>
         <source>Position:</source>
         <translation>Позиція:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1031"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2927"/>
         <source>Pinned</source>
         <translation>Закріплена</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1271"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2938"/>
         <source>Bottom</source>
         <translation>Внизу</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1276"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2939"/>
         <source>Left</source>
         <translation>Зліва</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1281"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2940"/>
         <source>Right</source>
         <translation>Справа</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1410"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2944"/>
         <source>Loop folder</source>
         <translation>Зациклити теку</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1417"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2945"/>
         <source>Go to the next folder</source>
         <translation>Перемкнутися на наступну</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1126"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2932"/>
         <source>Display style:</source>
         <translation>Стиль показу:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1159"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2934"/>
         <source>Simple</source>
         <translation>Простий</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1109"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2930"/>
         <source>Extended</source>
         <translation>Розширений</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1183"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2935"/>
         <source>Preview size:</source>
         <translation>Розмір превью:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1374"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2942"/>
         <source>Folder navigation</source>
         <translation>Навігація по теці</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1493"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2948"/>
         <source>A - Z</source>
         <translation>А - Я</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1498"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2949"/>
         <source>Z - A</source>
         <translation>Я - А</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1503"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2950"/>
         <source>Size</source>
         <translation>Розмір</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1508"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2951"/>
         <source>Size (desc)</source>
         <translation>Розмір (зв.)</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1513"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2952"/>
         <source>Oldest</source>
         <translation>Найстаріші</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1518"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2953"/>
         <source>Newest</source>
         <translation>Найновіші</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1476"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2947"/>
         <source>Default sorting mode:</source>
         <translation>Сортування за замовчуванням:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1713"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1734"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2959"/>
         <source>Slideshow</source>
         <translation>Слайд-шоу</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1796"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1817"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2962"/>
         <source>Loop slideshow</source>
         <translation>Зациклити слайд-шоу</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1733"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1754"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2960"/>
         <source>Switch interval:</source>
         <translation>Інтервал перемикання:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1764"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1785"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2961"/>
         <source>ms</source>
         <translation>мс</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="606"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2906"/>
         <source>Image info in window title</source>
         <translation>Інфо про зображення у заголовку вікна</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="643"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2912"/>
         <source>Fullscreen info bar</source>
         <translation>Повноекранна панель з інфо</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="656"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2913"/>
         <source>Status bar</source>
         <translation>Рядок стану</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="713"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2917"/>
         <source>Auto</source>
         <translation>Авто</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="689"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2914"/>
         <source>Zoom indicator:</source>
         <translation>Зум індикатор:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="435"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2902"/>
         <source>Requires application restart</source>
         <translation>Потребує перезапуск програми</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2889"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2917"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3011"/>
         <source>Use system colors</source>
         <translation>Системні кольори</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2899"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2927"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3012"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;modify&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;змінити&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2833"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2861"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3004"/>
         <source>Load preset:</source>
         <translation>Завантажити пресет:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="551"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2905"/>
         <source>User interface</source>
         <translation>Інтерфейс користувача</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="699"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2915"/>
         <source>On</source>
         <translation>Вмк</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="706"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2916"/>
         <source>Off</source>
         <translation>Вимк</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="753"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2918"/>
         <source>Automatic window resize</source>
         <translation>Авто розмір вікна</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="763"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2919"/>
         <source>Match displayed content</source>
         <translation>Підігнати під розмір контенту</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="799"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2920"/>
         <source>Screen area limit for auto resize:</source>
         <translation>Обмеження щодо розміру екрана:</translation>
     </message>
     <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="864"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2261"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2921"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2978"/>
+        <source>xx</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1119"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2931"/>
         <source>Previews only</source>
         <translation>Тільки превью</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1139"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2933"/>
         <source>Show filename and resolution</source>
         <translation>Показати назву та розмір</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1424"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2946"/>
         <source>After reaching the end:</source>
         <translation>При досягненні кінця теки:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1893"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1541"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2955"/>
+        <source>Apply sorting to folders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1555"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2956"/>
+        <source>Show hidden files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1914"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2963"/>
         <source>View</source>
         <translation>Перегляд</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1949"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1970"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2964"/>
         <source>Display options</source>
         <translation>Налаштування перегляду</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="2025"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2969"/>
         <source>Fit in window (stretch)</source>
         <translation>Вписати у вікно (розтягнути)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2026"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2047"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2970"/>
         <source>Keep fit mode when switching images</source>
         <translation>Не змінювати при перемиканні зображення</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2119"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2147"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2976"/>
         <source>Grid background on images with transparency</source>
         <translation>Фон-сітка на зображеннях із прозорістю</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2156"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2184"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2977"/>
         <source>Expand images, up to:</source>
         <translation>Збільшувати зображення, до:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2264"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2292"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2979"/>
         <source>Images smaller than window will be zoomed in</source>
         <translation>Зображення менші за розмір вікна будуть збільшені</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2323"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2351"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2981"/>
         <source>Unlock minimum zoom</source>
         <translation>Розблокувати мінімальний зум</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2333"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2361"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2982"/>
         <source>Always allow zooming below 100%</source>
         <translation>Завжди дозволяти зум менше ніж 100%</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2455"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2454"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2984"/>
+        <source>[step]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2483"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2985"/>
         <source>Use fixed zoom levels:</source>
         <translation>Використовувати фіксовані рівні зуму:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2499"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2527"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2986"/>
         <source>Load defaults</source>
         <translation>За замовчуванням</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2774"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2654"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2992"/>
+        <source>Nearest neighbor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2659"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2993"/>
+        <source>Bilinear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2802"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3003"/>
         <source>Theme</source>
         <translation>Тема</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2846"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2850"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2874"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2878"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3005"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3010"/>
         <source>Black</source>
         <translation>Чорний</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2855"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2883"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3006"/>
         <source>Dark</source>
         <translation>Темний</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2860"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2888"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3007"/>
         <source>Dark Blue</source>
         <translation>Темно-синій</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2865"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2893"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3008"/>
         <source>Light</source>
         <translation>Світлий</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3336"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3364"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3028"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="61"/>
         <source>Widget border</source>
         <translation>Межа віджетів</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3329"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3357"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3027"/>
         <source>Folder view top panel</source>
         <translation>Верхня панель галереї</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3132"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3160"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3016"/>
         <source>Background</source>
         <translation>Фон вікна</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3284"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3312"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3024"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="62"/>
         <source>Overlay background</source>
         <translation>Фон оверлеїв</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3405"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3433"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3031"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="63"/>
         <source>Overlay text</source>
         <translation>Текст оверлея</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3125"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3153"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3015"/>
         <source>Accent</source>
         <translation>Акцент</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3177"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3205"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3019"/>
         <source>Text</source>
         <translation>Текст</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3322"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3350"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3026"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="60"/>
         <source>Widget background</source>
         <translation>Фон віджетів</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3450"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3478"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3034"/>
         <source>Folder view background</source>
         <translation>Фон галереї</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3184"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3212"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3020"/>
         <source>Icons</source>
         <translation>Значки</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3443"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3471"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3033"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="64"/>
         <source>Scrollbars</source>
         <translation>Смуга прокрутки</translation>
@@ -1607,264 +1844,336 @@
         <translation type="obsolete">Фон-сітка на прозорих зображеннях</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3614"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3642"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3038"/>
         <source>Background blur (KDE)</source>
         <translation>Розмиття фону вікна (KDE)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3536"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3564"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3036"/>
         <source>Window opacity:</source>
         <translation>Непрозорість вікна:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3589"/>
-        <source>%</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2567"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2595"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2987"/>
         <source>Scaling quality</source>
         <translation>Якість масштабування</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2673"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2701"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2999"/>
         <source>When unchecked, nearest neighbor algorithm will be used for upscaling.</source>
         <translation>Якщо вимкнено, буде застосований алгоритм nearest neighbor.</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2676"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2704"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3001"/>
         <source>Smooth upscaling</source>
         <translation>Плавний апскейлінг</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2695"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2723"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3002"/>
         <source>Smooth animated images</source>
         <translation>Плавне масштабування анімацій</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2594"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2622"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2991"/>
         <source>Scaling filter:</source>
         <translation>Фільтр масштабування:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2626"/>
-        <source>Nearest neighbor</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2631"/>
-        <source>Bilinear</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2316"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2344"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2980"/>
         <source>Zoom options</source>
         <translation>Налаштування зуму</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2358"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2386"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2983"/>
         <source>Zoom step:</source>
         <translation>Крок зуму:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2426"/>
-        <source>[step]</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3896"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3943"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3051"/>
         <source>None</source>
         <translation>Нічого</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3901"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3948"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3052"/>
         <source>Touchpad</source>
         <translation>Трекпад</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3906"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3953"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3053"/>
         <source>Touchpad &amp; Mouse Wheel</source>
         <translation>Трекпад &amp; колесо миші</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3727"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4042"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3755"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4200"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3040"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3063"/>
         <source>Add</source>
         <translation>Додати</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3734"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4049"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3617"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3037"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3762"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4207"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3041"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3064"/>
         <source>Edit</source>
         <translation>Редагувати</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3747"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4056"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3775"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4214"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3042"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3065"/>
         <source>Remove</source>
         <translation>Видалити</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3776"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3804"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3043"/>
         <source>Reset to defaults</source>
         <translation>За замовчуванням</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3810"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3838"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3045"/>
         <source>Action</source>
         <translation>Дія</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3815"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3843"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3047"/>
         <source>Shortcut</source>
         <translation>Комбінація клавіш</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4237"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3898"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3048"/>
+        <source>Switch image by clicking window edges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3905"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3049"/>
+        <source>Visible edges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4007"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3056"/>
+        <source>Mouse scrolling speed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4051"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3057"/>
+        <source>[x]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4080"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3058"/>
+        <source>Trackpad detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4090"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3059"/>
+        <source>Disable if you have issues with mouse scrolling</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4395"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3072"/>
         <source>Thumbnailer thread count:</source>
         <translation>Кількість потоків для генератора превью:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4275"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4433"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3073"/>
         <source>2</source>
         <translation>2</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4196"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4354"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3068"/>
         <source>Preload the next/previous image. Results in a much faster image switching (at the expense of wasting more RAM).</source>
         <translation>Заважтажити наступне/попереднє зображення. Швидке перемикання зображень (за рахунок збільшеного використання пам&apos;яті).</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4199"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4357"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3070"/>
         <source>Use preloader (recommended)</source>
         <translation>Попереднє завантаження</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="633"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2909"/>
         <source>Turn this off if you are using a touchpad with libinput driver.</source>
         <translation>Вимкніть цю опцію якщо ви використовуєте ОС Linux з драйверами libinput.</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="636"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2911"/>
         <source>Enable smooth scrolling</source>
         <translation>Увімкнути плавну прокрутку</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2096"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2124"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2975"/>
         <source>Part of image that&apos;s focused after switching to 1:1</source>
         <translation>Яку частину зображення фокусувати в режимі 1:1</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3139"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3167"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3017"/>
         <source>Background (fullscreen mode)</source>
         <translation>Фон (повноекранний режим)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3521"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3549"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3035"/>
         <source>Other window tweaks</source>
         <translation>Інші налаштування вікна</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3867"/>
         <source>Mouse &amp; touchpad</source>
-        <translation>Мишка / тачпад</translation>
+        <translation type="vanished">Мишка / тачпад</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3888"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3935"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3050"/>
         <source>Scroll image with:</source>
         <translation>Прокручувати зображення з:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3932"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3979"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3055"/>
         <source>Note: you can also zoom by holding RMB and moving the mouse</source>
         <translation>Примітка: також ви можете зумувати утримуючи праву кл. миші</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4020"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4178"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3061"/>
         <source>Note: these will appear in &quot;Open with&quot; menu.</source>
         <translation>Примітка: ці записи будуть присутні в меню &quot;Відкрити в...&quot;</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4030"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4188"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3062"/>
         <source>Also, you can assign shortcuts to scripts (in &quot;Controls&quot; section).</source>
         <translation>Також ви можете призначити їм комбінації клавіш (див. секцію &quot;Керування&quot;).</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4209"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4367"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3071"/>
         <source>Load adjacent images in background</source>
         <translation>Завантажувати в фоні суміжні зображення</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4323"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4481"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3079"/>
         <source>Dynamically unload items to save memory</source>
         <translation>Динамічно вивантажувати елементи з пам&apos;яті</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4337"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4495"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3080"/>
         <source>Show save overlay when editing images</source>
         <translation>Показати оверлей збереження при редагуванні зображень</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4313"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4471"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3078"/>
         <source>Unload off-screen thumbnails</source>
         <translation>Вивантажувати превью поза кадром</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4437"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4595"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3084"/>
         <source>Confirm file delete (!)</source>
         <translation>Підтвердження для видалення файлів (!)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4479"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4637"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3086"/>
         <source>Memory allocation limit per image, MB:</source>
         <translation>Ліміт виділення пам&apos;яті на зображення, МБ:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4540"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4698"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3087"/>
         <source>Mpv binary:</source>
         <translation>Бінарний файл Mpv:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4581"/>
-        <source>...</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4451"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4609"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3085"/>
         <source>JXL animation support (experimental)</source>
         <translation>Підтримка JXL анімацій (експериментально)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4352"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4510"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3081"/>
         <source>JPEG save quality:</source>
         <translation>Якість JPEG при збереженні:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4396"/>
-        <source>q</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4306"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4464"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3077"/>
         <source>Use thumbnail cache (recommended)</source>
         <translation>Використовувати кеш превью (рекомендовано)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4425"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4554"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3082"/>
+        <source>q</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4583"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3083"/>
         <source>Confirm moving to trash</source>
         <translation>Підтвердження видалення у кошик</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4675"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4739"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3088"/>
+        <source>...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4833"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3089"/>
         <source>About qimgv</source>
         <translation>Про qimgv</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4726"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4884"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3090"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 hr { height: 1px; border-width: 0; }
+li.unchecked::marker { content: &quot;\2610&quot;; }
+li.checked::marker { content: &quot;\2612&quot;; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Noto Sans&apos;; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:10pt;&quot;&gt;This is a fast and easy to use image viewer&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:10pt;&quot;&gt;Features video support via libmpv&lt;/span&gt;&lt;/p&gt;
@@ -1877,20 +2186,23 @@ hr { height: 1px; border-width: 0; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:10pt;&quot;&gt;qimgv is licensed under &lt;/span&gt;&lt;a href=&quot;https://www.gnu.org/licenses/gpl-3.0.en.html&quot;&gt;&lt;span style=&quot; font-family:&apos;Droid Sans&apos;; font-size:10pt; text-decoration: underline; color:#007af4;&quot;&gt;GNU GPL Version 3&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;MS Shell Dlg 2&apos;; font-size:10pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:10pt;&quot;&gt;Report any issues / request features &lt;/span&gt;&lt;a href=&quot;https://github.com/easymodo/qimgv/issues&quot;&gt;&lt;span style=&quot; font-family:&apos;Droid Sans&apos;; font-size:10pt; text-decoration: underline; color:#007af4;&quot;&gt;here&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4817"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4977"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3112"/>
         <source>OK</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4824"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4984"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3113"/>
         <source>Apply</source>
         <translation>Застосувати</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4831"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4991"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3114"/>
         <source>Cancel</source>
         <translation>Відмінити</translation>
     </message>
@@ -1930,40 +2242,50 @@ hr { height: 1px; border-width: 0; }
         <translation>Колір тексту</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.cpp" line="563"/>
+        <location filename="../../gui/dialogs/settingsdialog.cpp" line="590"/>
         <source>Edit shortcut</source>
         <translation>Редагувати комбінацію клавіш</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.cpp" line="614"/>
+        <location filename="../../gui/dialogs/settingsdialog.cpp" line="641"/>
         <source>Navigate to mpv binary</source>
         <translation>Перейдіть до бінарного файлу mpv</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.cpp" line="649"/>
+        <source>Maximum</source>
+        <translation>Максимум</translation>
     </message>
 </context>
 <context>
     <name>ShortcutCreatorDialog</name>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="14"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="148"/>
         <source>New shortcut</source>
         <translation>Нова комбінація клавіш</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="34"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="149"/>
         <source>Action:</source>
         <translation>Дія:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="73"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="150"/>
         <source>Script:</source>
         <translation>Скріпт:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="117"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="151"/>
         <source>Shortcut:</source>
         <translation>Комбінація клавіш:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="124"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="152"/>
         <source>[Enter shortcut]</source>
         <translation>[Уведіть комбінацію]</translation>
     </message>
@@ -1971,32 +2293,32 @@ hr { height: 1px; border-width: 0; }
 <context>
     <name>main</name>
     <message>
-        <location filename="../../main.cpp" line="133"/>
+        <location filename="../../main.cpp" line="126"/>
         <source>File or directory path.</source>
         <translation>Шлях до файлу або директорії.</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="136"/>
+        <location filename="../../main.cpp" line="129"/>
         <source>Generate all thumbnails for directory.</source>
         <translation>Згенерувати превью для дикерторії.</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="137"/>
+        <location filename="../../main.cpp" line="130"/>
         <source>directory-path</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="139"/>
+        <location filename="../../main.cpp" line="132"/>
         <source>Thumbnail size. Current size is used if not specified.</source>
         <translation>Розмір превью. За замовчуванням буде використано поточний розмір.</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="140"/>
+        <location filename="../../main.cpp" line="133"/>
         <source>thumbnail-size</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="142"/>
+        <location filename="../../main.cpp" line="135"/>
         <source>Show build options.</source>
         <translation>Показати опції зборки.</translation>
     </message>

--- a/qimgv/res/translations/zh_CN.ts
+++ b/qimgv/res/translations/zh_CN.ts
@@ -5,11 +5,13 @@
     <name>ChangelogWindow</name>
     <message>
         <location filename="../../gui/overlays/changelogwindow.ui" line="154"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_changelogwindow.h" line="137"/>
         <source>Close, never show changelogs</source>
         <translation>关闭,从不显示更新日志</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/changelogwindow.ui" line="170"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_changelogwindow.h" line="138"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
@@ -17,62 +19,63 @@
 <context>
     <name>ContextMenu</name>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="55"/>
+        <location filename="../../gui/contextmenu.cpp" line="58"/>
         <source>Print</source>
         <translation type="unfinished">打印</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="59"/>
+        <location filename="../../gui/contextmenu.cpp" line="62"/>
         <source>Quick copy</source>
         <translation>快速拷贝</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="63"/>
+        <location filename="../../gui/contextmenu.cpp" line="66"/>
         <source>Quick move</source>
         <translation>快速移动</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="67"/>
+        <location filename="../../gui/contextmenu.cpp" line="70"/>
         <source>Move to trash</source>
         <translation>移到回收站</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="72"/>
+        <location filename="../../gui/contextmenu.cpp" line="75"/>
         <source>Open</source>
         <translation>打开</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="77"/>
+        <location filename="../../gui/contextmenu.cpp" line="80"/>
         <source>Folder View</source>
         <translation>文件夹视图</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="82"/>
+        <location filename="../../gui/contextmenu.cpp" line="85"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="85"/>
+        <location filename="../../gui/contextmenu.cpp" line="88"/>
         <source>Open with...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="91"/>
+        <location filename="../../gui/contextmenu.cpp" line="94"/>
         <source>Show in folder</source>
         <translation>在文件管理器中显示</translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="99"/>
+        <location filename="../../gui/contextmenu.cpp" line="102"/>
         <source>Back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.cpp" line="102"/>
+        <location filename="../../gui/contextmenu.cpp" line="105"/>
         <source>Configure menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/contextmenu.ui" line="229"/>
+        <location filename="../../gui/contextmenu.ui" line="236"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_contextmenu.h" line="449"/>
         <source>Edit</source>
         <translation type="unfinished">编辑</translation>
     </message>
@@ -94,228 +97,228 @@
 <context>
     <name>Core</name>
     <message>
-        <location filename="../../core.cpp" line="255"/>
+        <location filename="../../core.cpp" line="258"/>
         <source>Updated: </source>
         <translation>更新到: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="261"/>
+        <location filename="../../core.cpp" line="264"/>
         <source>Welcome to </source>
         <translation>欢迎使用 </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="261"/>
+        <location filename="../../core.cpp" line="264"/>
         <source> version </source>
         <translation> 版本 </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="268"/>
+        <location filename="../../core.cpp" line="271"/>
         <source>Shuffle mode: OFF</source>
         <translation>随机模式: 关闭</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="271"/>
+        <location filename="../../core.cpp" line="274"/>
         <source>Shuffle mode: ON</source>
         <translation>随机模式: 启用</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="280"/>
+        <location filename="../../core.cpp" line="283"/>
         <source>Slideshow: OFF</source>
         <translation>幻灯片播放：关闭</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="284"/>
+        <location filename="../../core.cpp" line="287"/>
         <source>Slideshow: ON</source>
         <translation>幻灯片播放：启用</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="355"/>
+        <location filename="../../core.cpp" line="358"/>
         <source>Delete </source>
         <translation>永久删除 </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="355"/>
+        <location filename="../../core.cpp" line="358"/>
         <source> items permanently?</source>
         <translation> 个项目?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="357"/>
+        <location filename="../../core.cpp" line="360"/>
         <source>Delete item permanently?</source>
         <translation>是否永久删除它们？</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="358"/>
+        <location filename="../../core.cpp" line="361"/>
         <source>Delete permanently</source>
         <translation>永久删除</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="374"/>
+        <location filename="../../core.cpp" line="377"/>
         <source>File removed</source>
         <translation>文件已删除</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="378"/>
+        <location filename="../../core.cpp" line="381"/>
         <source>Removed: </source>
         <translation>成功删除: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="378"/>
-        <location filename="../../core.cpp" line="408"/>
+        <location filename="../../core.cpp" line="381"/>
+        <location filename="../../core.cpp" line="411"/>
         <source> files</source>
         <translation> 个文件</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="389"/>
+        <location filename="../../core.cpp" line="392"/>
         <source>Move </source>
         <translation>移动 </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="389"/>
+        <location filename="../../core.cpp" line="392"/>
         <source> items to trash?</source>
         <translation> 个项目到回收站?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="391"/>
+        <location filename="../../core.cpp" line="394"/>
         <source>Move item to trash?</source>
         <translation>确认删除到回收站?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="392"/>
+        <location filename="../../core.cpp" line="395"/>
         <source>Move to trash</source>
         <translation>删除到回收站</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="404"/>
+        <location filename="../../core.cpp" line="407"/>
         <source>Moved to trash</source>
         <translation>删除到回收站</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="408"/>
+        <location filename="../../core.cpp" line="411"/>
         <source>Moved to trash: </source>
         <translation>移动到回收站： </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="463"/>
+        <location filename="../../core.cpp" line="466"/>
         <source>File copied</source>
         <translation>文件已拷贝</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="470"/>
+        <location filename="../../core.cpp" line="473"/>
         <source>Path copied</source>
         <translation>目录已拷贝</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="644"/>
-        <location filename="../../core.cpp" line="918"/>
-        <location filename="../../core.cpp" line="939"/>
+        <location filename="../../core.cpp" line="647"/>
+        <location filename="../../core.cpp" line="928"/>
+        <location filename="../../core.cpp" line="949"/>
         <source>File exists</source>
         <translation>文件已经存在</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="644"/>
+        <location filename="../../core.cpp" line="647"/>
         <source>Overwrite file?</source>
         <translation>覆盖文件吗?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="812"/>
-        <location filename="../../core.cpp" line="880"/>
+        <location filename="../../core.cpp" line="822"/>
+        <location filename="../../core.cpp" line="890"/>
         <source>Could not create directory </source>
         <translation>不能建立该目录 </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="916"/>
+        <location filename="../../core.cpp" line="926"/>
         <source>File moved.</source>
         <translation>文件已移动.</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="918"/>
-        <location filename="../../core.cpp" line="939"/>
+        <location filename="../../core.cpp" line="928"/>
+        <location filename="../../core.cpp" line="949"/>
         <source>Destination file exists. Overwrite?</source>
         <translation>目标文件已经存在. 覆盖吗?</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="937"/>
+        <location filename="../../core.cpp" line="947"/>
         <source>File copied.</source>
         <translation>文件已拷贝.</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="984"/>
+        <location filename="../../core.cpp" line="994"/>
         <source>Perform action &quot;</source>
         <translation>执行操作 \&quot;</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="984"/>
+        <location filename="../../core.cpp" line="994"/>
         <source>Changes will be saved immediately.</source>
         <translation>更改将立即保存.</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1002"/>
+        <location filename="../../core.cpp" line="1012"/>
         <source>Flip horizontal</source>
         <translation>水平翻转</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1006"/>
+        <location filename="../../core.cpp" line="1016"/>
         <source>Flip vertical</source>
         <translation>垂直翻转</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1010"/>
+        <location filename="../../core.cpp" line="1020"/>
         <source>Rotate</source>
         <translation>旋转</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1014"/>
+        <location filename="../../core.cpp" line="1024"/>
         <source>Resize</source>
         <translation>调整大小</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1020"/>
-        <location filename="../../core.cpp" line="1026"/>
+        <location filename="../../core.cpp" line="1030"/>
+        <location filename="../../core.cpp" line="1036"/>
         <source>Crop</source>
         <translation>裁剪</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1058"/>
+        <location filename="../../core.cpp" line="1068"/>
         <source>File saved</source>
         <translation>文件已保存</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1061"/>
+        <location filename="../../core.cpp" line="1071"/>
         <source>Could not save file</source>
         <translation>不能保存文件</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1171"/>
+        <location filename="../../core.cpp" line="1181"/>
         <source>Could not open image</source>
         <translation>不能打开图片</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1175"/>
+        <location filename="../../core.cpp" line="1185"/>
         <source>Can only print static images</source>
         <translation>只能打印静态图片</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1226"/>
+        <location filename="../../core.cpp" line="1236"/>
         <source>Could not open path: </source>
         <translation>不能打开的路径: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1260"/>
+        <location filename="../../core.cpp" line="1270"/>
         <source>Could not load folder: </source>
         <translation>不能载入的目录: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1413"/>
+        <location filename="../../core.cpp" line="1423"/>
         <source>End of directory.</source>
         <translation>目录末尾.</translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1452"/>
+        <location filename="../../core.cpp" line="1462"/>
         <source>Load failed: </source>
         <translation>加载失败: </translation>
     </message>
     <message>
-        <location filename="../../core.cpp" line="1496"/>
+        <location filename="../../core.cpp" line="1506"/>
         <source>Error: could not load image.</source>
         <translation>错误: 不能载入图片.</translation>
     </message>
@@ -324,76 +327,91 @@
     <name>CropPanel</name>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="107"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="370"/>
         <source>Selection</source>
         <translation>选择</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="125"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="371"/>
         <source>Width</source>
         <translation>宽度</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="161"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="372"/>
         <source>Height</source>
         <translation>高度</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="322"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="374"/>
         <source>Aspect Ratio</source>
         <translation>纵横比例</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="336"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="375"/>
         <source>Free</source>
         <translation>无</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="341"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="376"/>
         <source>Custom</source>
         <translation>定制比例</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="346"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="377"/>
         <source>Current Image</source>
         <translation>当前图片</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="351"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="378"/>
         <source>This Screen</source>
         <translation>此屏幕</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="356"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="379"/>
         <source>1:1</source>
         <translation>1:1</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="361"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="380"/>
         <source>4:3</source>
         <translation>4:3</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="366"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="381"/>
         <source>16:9</source>
         <translation>16:9</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="371"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="382"/>
         <source>16:10</source>
         <translation>16:10</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="499"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="385"/>
         <source>Crop</source>
         <translation>裁剪</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="512"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="386"/>
         <source>Crop &amp;&amp; Save</source>
         <translation>裁剪并保存</translation>
     </message>
     <message>
         <location filename="../../gui/panels/croppanel/croppanel.ui" line="527"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_croppanel.h" line="387"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
@@ -402,11 +420,13 @@
     <name>FVOptionsPopup</name>
     <message>
         <location filename="../../gui/folderview/fvoptionspopup.ui" line="32"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_fvoptionspopup.h" line="86"/>
         <source>Form</source>
         <translation>始于</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/fvoptionspopup.ui" line="53"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_fvoptionspopup.h" line="87"/>
         <source>View options</source>
         <translation>查看选项</translation>
     </message>
@@ -415,56 +435,67 @@
     <name>FileReplaceDialog</name>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="14"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="130"/>
         <source>Dialog</source>
         <translation>对话框</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="20"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="131"/>
         <source>title</source>
         <translation>标题</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="33"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="132"/>
         <source>Source:</source>
         <translation>来自:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="40"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="133"/>
         <source>src</source>
         <translation>src</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="50"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="134"/>
         <source>&gt;&gt;&gt;</source>
         <translation>&gt;&gt;&gt;</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="63"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="135"/>
         <source>Destination:</source>
         <translation>目标:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="70"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="136"/>
         <source>dst</source>
         <translation>dst</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="111"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="137"/>
         <source>Apply to all</source>
         <translation>适用于所有</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="118"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="138"/>
         <source>Yes</source>
         <translation>是</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="125"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="139"/>
         <source>No</source>
         <translation>否</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/filereplacedialog.ui" line="132"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_filereplacedialog.h" line="140"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
@@ -473,77 +504,93 @@
     <name>FolderView</name>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="17"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="410"/>
         <source>Form</source>
         <translation>来自</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="145"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="411"/>
         <source>[path]</source>
         <translation>[路径]</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="195"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="413"/>
         <source>FolderViewSlider</source>
         <translation>FolderViewSlider</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="242"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="416"/>
         <source>CheckableButton</source>
         <translation>CheckableButton</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="274"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="426"/>
         <source>PanelComboBox</source>
         <translation>PanelComboBox</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="281"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="418"/>
         <source>A - Z</source>
         <translation>A - Z</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="286"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="419"/>
         <source>Z - A</source>
         <translation>Z - A</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="291"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="420"/>
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="296"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="421"/>
         <source>Size (desc)</source>
         <translation>大小 (降序)</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="301"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="422"/>
         <source>Oldest</source>
         <translation>最旧</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="306"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="423"/>
         <source>Newest</source>
         <translation>最新</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="348"/>
         <location filename="../../gui/folderview/folderview.ui" line="373"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="429"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="432"/>
         <source>PanelButton</source>
         <translation>PanelButton</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="414"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="435"/>
         <source>PanelButtonRE</source>
         <translation>PanelButtonRE</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="476"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="438"/>
         <source>PlacesPanel</source>
         <translation>PlacesPanel</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="532"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="440"/>
         <source>BOOKMARKS</source>
         <translation>书签</translation>
     </message>
@@ -551,11 +598,15 @@
         <location filename="../../gui/folderview/folderview.ui" line="551"/>
         <location filename="../../gui/folderview/folderview.ui" line="638"/>
         <location filename="../../gui/folderview/folderview.ui" line="657"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="442"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="446"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="449"/>
         <source>PlacesPanelButton</source>
         <translation>PlacesPanelButton</translation>
     </message>
     <message>
         <location filename="../../gui/folderview/folderview.ui" line="611"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_folderview.h" line="444"/>
         <source>FILESYSTEM</source>
         <translation>文件系统</translation>
     </message>
@@ -564,11 +615,13 @@
     <name>ImageInfoOverlay</name>
     <message>
         <location filename="../../gui/overlays/imageinfooverlay.ui" line="65"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_imageinfooverlay.h" line="111"/>
         <source>OverlayHeaderWidget</source>
         <translation>OverlayHeaderWidget</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/imageinfooverlay.ui" line="99"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_imageinfooverlay.h" line="113"/>
         <source>EXIF Tags</source>
         <translation>EXIF标签</translation>
     </message>
@@ -584,35 +637,35 @@
 <context>
     <name>MW</name>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="536"/>
+        <location filename="../../gui/mainwindow.cpp" line="581"/>
         <source>Save File as...</source>
         <translation>文件另存为...</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="771"/>
+        <location filename="../../gui/mainwindow.cpp" line="816"/>
         <source>Folder view</source>
         <translation>文件夹视图</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="772"/>
-        <location filename="../../gui/mainwindow.cpp" line="773"/>
-        <location filename="../../gui/mainwindow.cpp" line="776"/>
-        <location filename="../../gui/mainwindow.cpp" line="777"/>
+        <location filename="../../gui/mainwindow.cpp" line="817"/>
+        <location filename="../../gui/mainwindow.cpp" line="818"/>
+        <location filename="../../gui/mainwindow.cpp" line="821"/>
+        <location filename="../../gui/mainwindow.cpp" line="822"/>
         <source>No file opened.</source>
         <translation>没有文件被打开.</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="838"/>
+        <location filename="../../gui/mainwindow.cpp" line="883"/>
         <source>Fit Window</source>
         <translation>适配窗口</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="842"/>
+        <location filename="../../gui/mainwindow.cpp" line="887"/>
         <source>Fit Width</source>
         <translation>适应宽度</translation>
     </message>
     <message>
-        <location filename="../../gui/mainwindow.cpp" line="846"/>
+        <location filename="../../gui/mainwindow.cpp" line="891"/>
         <source>Fit 1:1</source>
         <translation>适应 1:1</translation>
     </message>
@@ -621,71 +674,85 @@
     <name>PrintDialog</name>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="20"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="304"/>
         <source>Print image</source>
         <translation>打印图片</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="126"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="306"/>
         <source>Preview</source>
         <translation>预览</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="179"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="307"/>
         <source>Printer:</source>
         <translation>打印机:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="189"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="308"/>
         <source>&lt;No printers found&gt;</source>
         <translation>没找到打印机</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="271"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="309"/>
         <source>Page orientation:</source>
         <translation>页面风格:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="297"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="310"/>
         <source>Portrait</source>
         <translation>肖像</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="307"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="311"/>
         <source>Landscape</source>
         <translation>风景</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="348"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="312"/>
         <source>Color mode:</source>
         <translation>颜色:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="374"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="313"/>
         <source>Grayscale</source>
         <translation>黑白</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="384"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="314"/>
         <source>Color</source>
         <translation>参数</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="409"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="315"/>
         <source>Fit to page</source>
         <translation>符合页面</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="434"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="316"/>
         <source>Export PDF</source>
         <translation>导出为PDF</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="454"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="317"/>
         <source>Print</source>
         <translation>打印</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/printdialog.ui" line="464"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_printdialog.h" line="318"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
@@ -772,8 +839,7 @@
     <message>
         <location filename="../../utils/fileoperations.cpp" line="43"/>
         <source>Operation completed succesfully.</source>
-        <translatorcomment>操作成功完成.</translatorcomment>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../utils/fileoperations.cpp" line="45"/>
@@ -826,11 +892,14 @@
     <message>
         <location filename="../../gui/overlays/renameoverlay.ui" line="171"/>
         <location filename="../../gui/overlays/renameoverlay.ui" line="260"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_renameoverlay.h" line="213"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_renameoverlay.h" line="214"/>
         <source>Rename</source>
         <translation>重命名</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/renameoverlay.ui" line="273"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_renameoverlay.h" line="215"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
@@ -839,151 +908,181 @@
     <name>ResizeDialog</name>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="32"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="358"/>
         <source>Resize</source>
         <translation>调整大小</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="63"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="359"/>
         <source>By Percent:</source>
         <translation>按百分比:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="79"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="360"/>
         <source>By Absolute Size:</source>
         <translation>按绝对尺寸：</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="98"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="361"/>
         <source>Percent:</source>
         <translation>百分比:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="119"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="362"/>
         <source>Width:</source>
         <translation>宽度:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="205"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="363"/>
         <source>Height:</source>
         <translation>高度:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="275"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="364"/>
         <source>Keep aspect ratio</source>
         <translation>保持纵横比例</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="304"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="365"/>
         <source>Filter:</source>
         <translation>过滤器:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="330"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="366"/>
         <source>Nearest</source>
         <translation>Nearest</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="335"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="367"/>
         <source>Bilinear</source>
         <translation>Bilinear</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="340"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="368"/>
         <source>Bicubic</source>
         <translation>Bicubic</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="345"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="369"/>
         <source>Lanczos3</source>
         <translation>Lanczos3</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="358"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="371"/>
         <source>Common sizes:</source>
         <translation>正常尺寸:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="392"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="372"/>
         <source>Select:</source>
         <translation>选择:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="397"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="373"/>
         <source>1366 x 768</source>
         <translation>1366 x 768</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="402"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="374"/>
         <source>1440 x 900</source>
         <translation>1440 x 900</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="407"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="375"/>
         <source>1440 x 1050</source>
         <translation>1440 x 1050</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="412"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="376"/>
         <source>1600 x 1200</source>
         <translation>1600 x 1200</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="417"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="377"/>
         <source>1920 x 1080 (FullHD)</source>
         <translation>1920 x 1080 (FullHD)</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="422"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="378"/>
         <source>1920 x 1200 (FullHD)</source>
         <translation>1920 x 1200 (FullHD)</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="427"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="379"/>
         <source>2560 x 1080</source>
         <translation>2560 x 1080</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="432"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="380"/>
         <source>2560 x 1440</source>
         <translation>2560 x 1440</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="437"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="381"/>
         <source>2560 x 1600</source>
         <translation>2560 x 1600</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="442"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="382"/>
         <source>3840 x 1600 (UW 4K)</source>
         <translation>3840 x 1600 (UW 4K)</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="447"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="383"/>
         <source>3840 x 2160 (UHD-1)</source>
         <translation>3840 x 2160 (UHD-1)</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="470"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="385"/>
         <source>Fit to desktop</source>
         <translation>适合桌面</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="489"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="386"/>
         <source>Fill desktop (expanding)</source>
         <translation>填充桌面（扩展）</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="508"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="387"/>
         <source>Reset</source>
         <translation>重置</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="575"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="388"/>
         <source>OK</source>
         <translation>确认</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/resizedialog.ui" line="594"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_resizedialog.h" line="389"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
@@ -1035,21 +1134,25 @@
     <name>SaveConfirmOverlay</name>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="81"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="145"/>
         <source>Unsaved edits</source>
         <translation>未保存的编辑</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="127"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="146"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="140"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="147"/>
         <source>Save as</source>
         <translation>另存为</translation>
     </message>
     <message>
         <location filename="../../gui/overlays/saveconfirmoverlay.ui" line="169"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_saveconfirmoverlay.h" line="148"/>
         <source>Discard</source>
         <translation>放弃</translation>
     </message>
@@ -1058,43 +1161,49 @@
     <name>ScriptEditorDialog</name>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="48"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="208"/>
         <source>Command:</source>
         <translation>命令:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="84"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="209"/>
         <source>NOTE: make sure your .sh script has execute flag.</source>
         <translation>注意: 确认你的 .sh 脚本具有可执行权限.</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="91"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="210"/>
         <source>Name:</source>
         <translation>名称:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="148"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="212"/>
         <source>Wait to finish</source>
         <translation>等待完成</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="218"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="214"/>
         <source>Create</source>
         <translation>创建</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.ui" line="225"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_scripteditordialog.h" line="215"/>
         <source>Cancel</source>
         <translation>取消</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/scripteditordialog.cpp" line="11"/>
-        <source>Keywords:</source>
-        <translation>关键字:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.cpp" line="10"/>
         <source>New application/script</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/scripteditordialog.cpp" line="11"/>
+        <source>Keywords:</source>
+        <translation>关键字:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/scripteditordialog.cpp" line="22"/>
@@ -1127,404 +1236,936 @@
     <name>SettingsDialog</name>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="47"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2892"/>
         <source>Preferences</source>
         <translation>首选项</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="53"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2894"/>
         <source>SettingsDialog</source>
         <translation>SettingsDialog</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="339"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2900"/>
         <source>General</source>
         <translation>常规</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3666"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3694"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3039"/>
         <source>Controls</source>
         <translation>控制中心</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3964"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4122"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3060"/>
         <source>Scripts</source>
         <translation>脚本</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4139"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4297"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3066"/>
         <source>Advanced</source>
         <translation>高级</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="415"/>
-        <source>Language:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="473"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2903"/>
         <source>Open in fullscreen</source>
         <translation>打开时全屏</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="480"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2904"/>
         <source>Start in folder view by default</source>
         <translation>默认在文件夹视图中启动</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="626"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2907"/>
         <source>Auto-hide cursor</source>
         <translation>自动隐藏鼠标</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1973"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1994"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2965"/>
         <source>Image fit:</source>
         <translation>图像匹配:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1990"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2011"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2967"/>
         <source>Stretch to width</source>
         <translation>拉伸到宽度</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1997"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2018"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2968"/>
         <source>1:1</source>
         <translation>1:1</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1980"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2001"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2966"/>
         <source>Fit in window</source>
         <translation>自适应窗口</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1266"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2057"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2085"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2937"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2972"/>
         <source>Top</source>
         <translation>顶部</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2064"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2092"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2973"/>
         <source>Center</source>
         <translation>中间</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2071"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2099"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2974"/>
         <source>At cursor</source>
         <translation>光标处</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2050"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2078"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2971"/>
         <source>Focus in 1:1 mode:</source>
         <translation>以1:1模式聚焦:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="864"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2233"/>
-        <source>xx</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1602"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1623"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2957"/>
         <source>Video playback</source>
         <translation>视频播放</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1644"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1665"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2958"/>
         <source>Play sounds</source>
         <translation>播放声音</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="962"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2925"/>
         <source>Thumbnail panel</source>
         <translation>缩略图面板</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1258"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2936"/>
         <source>Position:</source>
         <translation>位置:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1271"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2938"/>
         <source>Bottom</source>
         <translation>底部</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1126"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2932"/>
         <source>Display style:</source>
         <translation>显示样式:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1159"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2934"/>
         <source>Simple</source>
         <translation>简易</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1109"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2930"/>
         <source>Extended</source>
         <translation>扩展</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1374"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2942"/>
         <source>Folder navigation</source>
         <translation>文件夹导航</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1493"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2948"/>
         <source>A - Z</source>
         <translation>A - Z</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1498"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2949"/>
         <source>Z - A</source>
         <translation>Z - A</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1503"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2950"/>
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1508"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2951"/>
         <source>Size (desc)</source>
         <translation>大小 (降序)</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1513"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2952"/>
         <source>Oldest</source>
         <translation>最旧</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1518"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2953"/>
         <source>Newest</source>
         <translation>最新</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="1476"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2947"/>
         <source>Default sorting mode:</source>
         <translation>标准排序模式:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1713"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1734"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2959"/>
         <source>Slideshow</source>
         <translation>幻灯片</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1796"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1817"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2962"/>
         <source>Loop slideshow</source>
         <translation>循环幻灯片放映</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1733"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1754"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2960"/>
         <source>Switch interval:</source>
         <translation>切换间隔:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1764"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1785"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2961"/>
         <source>ms</source>
         <translation>毫秒</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="606"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2906"/>
         <source>Image info in window title</source>
         <translation>窗口标题上显示图像信息</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="643"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2912"/>
         <source>Fullscreen info bar</source>
         <translation>全屏信息栏</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="656"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2913"/>
         <source>Status bar</source>
         <translation>状态栏</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="713"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2917"/>
         <source>Auto</source>
         <translation>自动</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="689"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2914"/>
         <source>Zoom indicator:</source>
         <translation>放大指示器:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1410"/>
-        <source>Loop folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1417"/>
-        <source>Go to the next folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1400"/>
-        <source>Stop</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="435"/>
-        <source>Requires application restart</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2889"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2917"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3011"/>
         <source>Use system colors</source>
         <translation>使用系统颜色</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2899"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2927"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3012"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;modify&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;修改&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2833"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2861"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3004"/>
         <source>Load preset:</source>
         <translation>加载预设:</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="551"/>
-        <source>User interface</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="699"/>
-        <source>On</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="706"/>
-        <source>Off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="753"/>
-        <source>Automatic window resize</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="763"/>
-        <source>Match displayed content</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="799"/>
-        <source>Screen area limit for auto resize:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1031"/>
-        <source>Pinned</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1119"/>
-        <source>Previews only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1139"/>
-        <source>Show filename and resolution</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1424"/>
-        <source>After reaching the end:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1893"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1949"/>
-        <source>Display options</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../gui/dialogs/settingsdialog.ui" line="2025"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2969"/>
         <source>Fit in window (stretch)</source>
         <translation>自适应窗口 (拉伸)</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2026"/>
-        <source>Keep fit mode when switching images</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2119"/>
-        <source>Grid background on images with transparency</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2156"/>
-        <source>Expand images, up to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2264"/>
-        <source>Images smaller than window will be zoomed in</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2323"/>
-        <source>Unlock minimum zoom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2333"/>
-        <source>Always allow zooming below 100%</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2455"/>
-        <source>Use fixed zoom levels:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2499"/>
-        <source>Load defaults</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2774"/>
-        <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2846"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2850"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2874"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2878"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3005"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3010"/>
         <source>Black</source>
         <translation>黑色</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2855"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2883"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3006"/>
         <source>Dark</source>
         <translation>深黑</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2860"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2888"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3007"/>
         <source>Dark Blue</source>
         <translation>深蓝色</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2865"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2893"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3008"/>
         <source>Light</source>
         <translation>光亮</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3336"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3364"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3028"/>
         <location filename="../../gui/dialogs/settingsdialog.cpp" line="61"/>
         <source>Widget border</source>
         <translation>窗口部件边框</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4726"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3357"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3027"/>
+        <source>Folder view top panel</source>
+        <translation>文件夹视图顶部面板</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3160"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3016"/>
+        <source>Background</source>
+        <translation>背景色</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3312"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3024"/>
+        <location filename="../../gui/dialogs/settingsdialog.cpp" line="62"/>
+        <source>Overlay background</source>
+        <translation>叠加背景色</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3433"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3031"/>
+        <location filename="../../gui/dialogs/settingsdialog.cpp" line="63"/>
+        <source>Overlay text</source>
+        <translation>覆盖文本</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3153"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3015"/>
+        <source>Accent</source>
+        <translation>点缀</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3205"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3019"/>
+        <source>Text</source>
+        <translation>文本</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3350"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3026"/>
+        <location filename="../../gui/dialogs/settingsdialog.cpp" line="60"/>
+        <source>Widget background</source>
+        <translation>部件背景色</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3478"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3034"/>
+        <source>Folder view background</source>
+        <translation>文件夹视图背景色</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3212"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3020"/>
+        <source>Icons</source>
+        <translation>图标</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3471"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3033"/>
+        <location filename="../../gui/dialogs/settingsdialog.cpp" line="64"/>
+        <source>Scrollbars</source>
+        <translation>滚动条</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3642"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3038"/>
+        <source>Background blur (KDE)</source>
+        <translation>背景防蓝光 (KDE)</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3564"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3036"/>
+        <source>Window opacity:</source>
+        <translation>窗口不透明度:</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3617"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3037"/>
+        <source>%</source>
+        <translation>%</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2595"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2987"/>
+        <source>Scaling quality</source>
+        <translation>缩放质量</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2701"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2999"/>
+        <source>When unchecked, nearest neighbor algorithm will be used for upscaling.</source>
+        <translation>取消选中时, 使用nearest neighbo算法进行放大.</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2704"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3001"/>
+        <source>Smooth upscaling</source>
+        <translation>平滑放大</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2723"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3002"/>
+        <source>Smooth animated images</source>
+        <translation>平滑动画图像</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2622"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2991"/>
+        <source>Scaling filter:</source>
+        <translation>缩放过滤器:</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2654"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2992"/>
+        <source>Nearest neighbor</source>
+        <translation>Nearest neighbor</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2659"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2993"/>
+        <source>Bilinear</source>
+        <translation>Bilinear</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2344"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2980"/>
+        <source>Zoom options</source>
+        <translation>放大功能</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2386"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2983"/>
+        <source>Zoom step:</source>
+        <translation>缩放倍数:</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2454"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2984"/>
+        <source>[step]</source>
+        <translation>[step]</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3943"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3051"/>
+        <source>None</source>
+        <translation>无</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3948"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3052"/>
+        <source>Touchpad</source>
+        <translation>触摸板</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3953"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3053"/>
+        <source>Touchpad &amp; Mouse Wheel</source>
+        <translation>触摸板与鼠标中键</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3755"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4200"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3040"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3063"/>
+        <source>Add</source>
+        <translation>添加</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="415"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2901"/>
+        <source>Language:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="435"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2902"/>
+        <source>Requires application restart</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="551"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2905"/>
+        <source>User interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="699"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2915"/>
+        <source>On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="706"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2916"/>
+        <source>Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="753"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2918"/>
+        <source>Automatic window resize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="763"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2919"/>
+        <source>Match displayed content</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="799"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2920"/>
+        <source>Screen area limit for auto resize:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="864"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2261"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2921"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2978"/>
+        <source>xx</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1018"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2926"/>
+        <source>Crop previews</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1031"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2927"/>
+        <source>Pinned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1050"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2928"/>
+        <source>Disable in windowed mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1057"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2929"/>
+        <source>Center selected image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1119"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2931"/>
+        <source>Previews only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1139"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2933"/>
+        <source>Show filename and resolution</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1183"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2935"/>
+        <source>Preview size:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1276"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2939"/>
+        <source>Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1281"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2940"/>
+        <source>Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1400"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2943"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1410"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2944"/>
+        <source>Loop folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1417"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2945"/>
+        <source>Go to the next folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1424"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2946"/>
+        <source>After reaching the end:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1541"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2955"/>
+        <source>Apply sorting to folders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1555"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2956"/>
+        <source>Show hidden files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1914"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2963"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="1970"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2964"/>
+        <source>Display options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2047"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2970"/>
+        <source>Keep fit mode when switching images</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2124"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2975"/>
+        <source>Part of image that&apos;s focused after switching to 1:1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2147"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2976"/>
+        <source>Grid background on images with transparency</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2184"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2977"/>
+        <source>Expand images, up to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2292"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2979"/>
+        <source>Images smaller than window will be zoomed in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2351"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2981"/>
+        <source>Unlock minimum zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2361"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2982"/>
+        <source>Always allow zooming below 100%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2483"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2985"/>
+        <source>Use fixed zoom levels:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2527"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2986"/>
+        <source>Load defaults</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="2802"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3003"/>
+        <source>Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3167"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3017"/>
+        <source>Background (fullscreen mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3549"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3035"/>
+        <source>Other window tweaks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3762"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4207"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3041"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3064"/>
+        <source>Edit</source>
+        <translation>编辑</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3775"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4214"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3042"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3065"/>
+        <source>Remove</source>
+        <translation>删除</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3804"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3043"/>
+        <source>Reset to defaults</source>
+        <translation>重置为标准</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3838"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3045"/>
+        <source>Action</source>
+        <translation>行为</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3843"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3047"/>
+        <source>Shortcut</source>
+        <translation>快捷键</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3898"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3048"/>
+        <source>Switch image by clicking window edges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3905"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3049"/>
+        <source>Visible edges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3935"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3050"/>
+        <source>Scroll image with:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="3979"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3055"/>
+        <source>Note: you can also zoom by holding RMB and moving the mouse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4007"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3056"/>
+        <source>Mouse scrolling speed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4051"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3057"/>
+        <source>[x]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4080"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3058"/>
+        <source>Trackpad detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4090"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3059"/>
+        <source>Disable if you have issues with mouse scrolling</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4178"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3061"/>
+        <source>Note: these will appear in &quot;Open with&quot; menu.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4188"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3062"/>
+        <source>Also, you can assign shortcuts to scripts (in &quot;Controls&quot; section).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4354"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3068"/>
+        <source>Preload the next/previous image. Results in a much faster image switching (at the expense of wasting more RAM).</source>
+        <translation>预加载下一个/上一个图像.更快的图像切换 (以浪费内存为代价).</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4357"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3070"/>
+        <source>Use preloader (recommended)</source>
+        <translation>使用预加载程序 (推荐)</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4367"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3071"/>
+        <source>Load adjacent images in background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4481"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3079"/>
+        <source>Dynamically unload items to save memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4510"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3081"/>
+        <source>JPEG save quality:</source>
+        <translation>JPEG 保存质量:</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4554"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3082"/>
+        <source>q</source>
+        <translation>q</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4395"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3072"/>
+        <source>Thumbnailer thread count:</source>
+        <translation>创建略缩图的线程数:</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4433"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3073"/>
+        <source>2</source>
+        <translation>2</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4471"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3078"/>
+        <source>Unload off-screen thumbnails</source>
+        <translation>卸载屏幕外的缩略图</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4495"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3080"/>
+        <source>Show save overlay when editing images</source>
+        <translation>在编辑图像时显示保存覆盖</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4464"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3077"/>
+        <source>Use thumbnail cache (recommended)</source>
+        <translation>使用缩略图缓存 (推荐)</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4698"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3087"/>
+        <source>Mpv binary:</source>
+        <translation>Mpv播放器路径:</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4739"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3088"/>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="633"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2909"/>
+        <source>Turn this off if you are using a touchpad with libinput driver.</source>
+        <translation>如果使用带libinput驱动程序的触摸板,请关闭此选项.</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="636"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="2911"/>
+        <source>Enable smooth scrolling</source>
+        <translation>开启平滑滚动</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4583"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3083"/>
+        <source>Confirm moving to trash</source>
+        <translation>删除到回收站时需确认</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4595"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3084"/>
+        <source>Confirm file delete (!)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4609"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3085"/>
+        <source>JXL animation support (experimental)</source>
+        <translation>JXL 动画支持 (实验)</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4637"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3086"/>
+        <source>Memory allocation limit per image, MB:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4833"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3089"/>
+        <source>About qimgv</source>
+        <translation>关于 qimgv</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4884"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3090"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 hr { height: 1px; border-width: 0; }
+li.unchecked::marker { content: &quot;\2610&quot;; }
+li.checked::marker { content: &quot;\2612&quot;; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Noto Sans&apos;; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:10pt;&quot;&gt;This is a fast and easy to use image viewer&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:10pt;&quot;&gt;Features video support via libmpv&lt;/span&gt;&lt;/p&gt;
@@ -1540,354 +2181,20 @@ hr { height: 1px; border-width: 0; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3329"/>
-        <source>Folder view top panel</source>
-        <translation>文件夹视图顶部面板</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3132"/>
-        <source>Background</source>
-        <translation>背景色</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3284"/>
-        <location filename="../../gui/dialogs/settingsdialog.cpp" line="62"/>
-        <source>Overlay background</source>
-        <translation>叠加背景色</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3405"/>
-        <location filename="../../gui/dialogs/settingsdialog.cpp" line="63"/>
-        <source>Overlay text</source>
-        <translation>覆盖文本</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3125"/>
-        <source>Accent</source>
-        <translation>点缀</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3177"/>
-        <source>Text</source>
-        <translation>文本</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3322"/>
-        <location filename="../../gui/dialogs/settingsdialog.cpp" line="60"/>
-        <source>Widget background</source>
-        <translation>部件背景色</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3450"/>
-        <source>Folder view background</source>
-        <translation>文件夹视图背景色</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3184"/>
-        <source>Icons</source>
-        <translation>图标</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3443"/>
-        <location filename="../../gui/dialogs/settingsdialog.cpp" line="64"/>
-        <source>Scrollbars</source>
-        <translation>滚动条</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3614"/>
-        <source>Background blur (KDE)</source>
-        <translation>背景防蓝光 (KDE)</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3536"/>
-        <source>Window opacity:</source>
-        <translation>窗口不透明度:</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3589"/>
-        <source>%</source>
-        <translation>%</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2567"/>
-        <source>Scaling quality</source>
-        <translation>缩放质量</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2673"/>
-        <source>When unchecked, nearest neighbor algorithm will be used for upscaling.</source>
-        <translation>取消选中时, 使用nearest neighbo算法进行放大.</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2676"/>
-        <source>Smooth upscaling</source>
-        <translation>平滑放大</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2695"/>
-        <source>Smooth animated images</source>
-        <translation>平滑动画图像</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2594"/>
-        <source>Scaling filter:</source>
-        <translation>缩放过滤器:</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2626"/>
-        <source>Nearest neighbor</source>
-        <translation>Nearest neighbor</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2631"/>
-        <source>Bilinear</source>
-        <translation>Bilinear</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2316"/>
-        <source>Zoom options</source>
-        <translation>放大功能</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2358"/>
-        <source>Zoom step:</source>
-        <translation>缩放倍数:</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2426"/>
-        <source>[step]</source>
-        <translation>[step]</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3896"/>
-        <source>None</source>
-        <translation>无</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3901"/>
-        <source>Touchpad</source>
-        <translation>触摸板</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3906"/>
-        <source>Touchpad &amp; Mouse Wheel</source>
-        <translation>触摸板与鼠标中键</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3727"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4042"/>
-        <source>Add</source>
-        <translation>添加</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3734"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4049"/>
-        <source>Edit</source>
-        <translation>编辑</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3747"/>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4056"/>
-        <source>Remove</source>
-        <translation>删除</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3776"/>
-        <source>Reset to defaults</source>
-        <translation>重置为标准</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3810"/>
-        <source>Action</source>
-        <translation>行为</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3815"/>
-        <source>Shortcut</source>
-        <translation>快捷键</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4196"/>
-        <source>Preload the next/previous image. Results in a much faster image switching (at the expense of wasting more RAM).</source>
-        <translation>预加载下一个/上一个图像.更快的图像切换 (以浪费内存为代价).</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4199"/>
-        <source>Use preloader (recommended)</source>
-        <translation>使用预加载程序 (推荐)</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4209"/>
-        <source>Load adjacent images in background</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4352"/>
-        <source>JPEG save quality:</source>
-        <translation>JPEG 保存质量:</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4396"/>
-        <source>q</source>
-        <translation>q</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4323"/>
-        <source>Dynamically unload items to save memory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4237"/>
-        <source>Thumbnailer thread count:</source>
-        <translation>创建略缩图的线程数:</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1050"/>
-        <source>Disable in windowed mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1018"/>
-        <source>Crop previews</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1057"/>
-        <source>Center selected image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1276"/>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1281"/>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="1183"/>
-        <source>Preview size:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4275"/>
-        <source>2</source>
-        <translation>2</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4313"/>
-        <source>Unload off-screen thumbnails</source>
-        <translation>卸载屏幕外的缩略图</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4337"/>
-        <source>Show save overlay when editing images</source>
-        <translation>在编辑图像时显示保存覆盖</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4306"/>
-        <source>Use thumbnail cache (recommended)</source>
-        <translation>使用缩略图缓存 (推荐)</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4479"/>
-        <source>Memory allocation limit per image, MB:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4540"/>
-        <source>Mpv binary:</source>
-        <translation>Mpv播放器路径:</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4581"/>
-        <source>...</source>
-        <translation>...</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="633"/>
-        <source>Turn this off if you are using a touchpad with libinput driver.</source>
-        <translation>如果使用带libinput驱动程序的触摸板,请关闭此选项.</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="636"/>
-        <source>Enable smooth scrolling</source>
-        <translation>开启平滑滚动</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="2096"/>
-        <source>Part of image that&apos;s focused after switching to 1:1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3139"/>
-        <source>Background (fullscreen mode)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3521"/>
-        <source>Other window tweaks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3867"/>
-        <source>Mouse &amp; touchpad</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3888"/>
-        <source>Scroll image with:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="3932"/>
-        <source>Note: you can also zoom by holding RMB and moving the mouse</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4020"/>
-        <source>Note: these will appear in &quot;Open with&quot; menu.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4030"/>
-        <source>Also, you can assign shortcuts to scripts (in &quot;Controls&quot; section).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4425"/>
-        <source>Confirm moving to trash</source>
-        <translation>删除到回收站时需确认</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4437"/>
-        <source>Confirm file delete (!)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4451"/>
-        <source>JXL animation support (experimental)</source>
-        <translation>JXL 动画支持 (实验)</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4675"/>
-        <source>About qimgv</source>
-        <translation>关于 qimgv</translation>
-    </message>
-    <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4817"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4977"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3112"/>
         <source>OK</source>
         <translation>确认</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4824"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4984"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3113"/>
         <source>Apply</source>
         <translation>应用</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.ui" line="4831"/>
+        <location filename="../../gui/dialogs/settingsdialog.ui" line="4991"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_settingsdialog.h" line="3114"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
@@ -1927,40 +2234,50 @@ hr { height: 1px; border-width: 0; }
         <translation>文本颜色</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.cpp" line="563"/>
+        <location filename="../../gui/dialogs/settingsdialog.cpp" line="590"/>
         <source>Edit shortcut</source>
         <translation>编辑快捷键</translation>
     </message>
     <message>
-        <location filename="../../gui/dialogs/settingsdialog.cpp" line="614"/>
+        <location filename="../../gui/dialogs/settingsdialog.cpp" line="641"/>
         <source>Navigate to mpv binary</source>
         <translation>定位mpv文件路径</translation>
+    </message>
+    <message>
+        <location filename="../../gui/dialogs/settingsdialog.cpp" line="649"/>
+        <source>Maximum</source>
+        <translation>最大</translation>
     </message>
 </context>
 <context>
     <name>ShortcutCreatorDialog</name>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="14"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="148"/>
         <source>New shortcut</source>
         <translation>新快捷键</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="34"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="149"/>
         <source>Action:</source>
         <translation>行为:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="73"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="150"/>
         <source>Script:</source>
         <translation>脚本:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="117"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="151"/>
         <source>Shortcut:</source>
         <translation>快捷键:</translation>
     </message>
     <message>
         <location filename="../../gui/dialogs/shortcutcreatordialog.ui" line="124"/>
+        <location filename="../../../build/qimgv/qimgv_autogen/include/ui_shortcutcreatordialog.h" line="152"/>
         <source>[Enter shortcut]</source>
         <translation>[输入快捷方式]</translation>
     </message>
@@ -1968,32 +2285,32 @@ hr { height: 1px; border-width: 0; }
 <context>
     <name>main</name>
     <message>
-        <location filename="../../main.cpp" line="133"/>
+        <location filename="../../main.cpp" line="126"/>
         <source>File or directory path.</source>
         <translation>文件或目录所在路径.</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="136"/>
+        <location filename="../../main.cpp" line="129"/>
         <source>Generate all thumbnails for directory.</source>
         <translation>为该目录下的所有文件生成略缩图.</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="137"/>
+        <location filename="../../main.cpp" line="130"/>
         <source>directory-path</source>
         <translation>目录所在路径</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="139"/>
+        <location filename="../../main.cpp" line="132"/>
         <source>Thumbnail size. Current size is used if not specified.</source>
         <translation>缩略图大小. 如果未指定, 则使用当前大小.</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="140"/>
+        <location filename="../../main.cpp" line="133"/>
         <source>thumbnail-size</source>
         <translation>略缩图大小</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="142"/>
+        <location filename="../../main.cpp" line="135"/>
         <source>Show build options.</source>
         <translation>显示编译选项.</translation>
     </message>

--- a/qimgv/settings.cpp
+++ b/qimgv/settings.cpp
@@ -1197,3 +1197,11 @@ bool Settings::showHiddenFiles() {
 void Settings::setShowHiddenFiles(bool mode) {
     settings->settingsConf->setValue("showHiddenFiles", mode);
 }
+//------------------------------------------------------------------------------
+int Settings::zoomPreservationMode() {
+    return settings->settingsConf->value("zoomPreservationMode", 0).toInt();
+}
+
+void Settings::setZoomPreservationMode(int mode) {
+    settings->settingsConf->setValue("zoomPreservationMode", mode);
+}

--- a/qimgv/settings.cpp
+++ b/qimgv/settings.cpp
@@ -824,7 +824,7 @@ void Settings::setExpandImage(bool mode) {
 }
 //------------------------------------------------------------------------------
 int Settings::expandLimit() {
-    return settings->settingsConf->value("expandLimit", 2).toInt();
+    return settings->settingsConf->value("expandLimit", 1).toInt();
 }
 
 void Settings::setExpandLimit(int value) {

--- a/qimgv/settings.h
+++ b/qimgv/settings.h
@@ -309,6 +309,9 @@ public:
 
     bool showHiddenFiles();
     void setShowHiddenFiles(bool mode);
+    
+    int zoomPreservationMode();
+    void setZoomPreservationMode(int mode);
 
 private:
     explicit Settings(QObject *parent = nullptr);

--- a/qimgv/utils/actions.cpp
+++ b/qimgv/utils/actions.cpp
@@ -90,6 +90,7 @@ void Actions::init() {
     mActions.insert("lockView", QVersionNumber(0,9,2));
     mActions.insert("print", QVersionNumber(1,0,0));
     mActions.insert("toggleFullscreenInfoBar", QVersionNumber(1,0,0));
+    mActions.insert("zoomInCenterCursor", QVersionNumber(1,0,3));
     mActions.insert("pasteFile", QVersionNumber(1,0,3));
 }
 

--- a/qimgv/utils/actions.cpp
+++ b/qimgv/utils/actions.cpp
@@ -87,10 +87,11 @@ void Actions::init() {
     mActions.insert("seekVideoForward", QVersionNumber(0,9,2));
     mActions.insert("seekVideoBackward", QVersionNumber(0,9,2));
     mActions.insert("lockZoom", QVersionNumber(0,9,2));
-    mActions.insert("lockView", QVersionNumber(0,9,2));
     mActions.insert("print", QVersionNumber(1,0,0));
     mActions.insert("toggleFullscreenInfoBar", QVersionNumber(1,0,0));
     mActions.insert("zoomInCenterCursor", QVersionNumber(1,0,3));
     mActions.insert("pasteFile", QVersionNumber(1,0,3));
+    mActions.insert("togglePreserveView", QVersionNumber(1,0,3));
+    mActions.insert("togglePreserveCurrentView", QVersionNumber(1,0,3));
 }
 


### PR DESCRIPTION
Hello there,
I compared many image viewers and found qimgv to be the best, especially because of the huge flexibility with keyboard shortcuts, actions and scripts.
But I also noticed some things that annoyed me, mainly the default zoom every image viewer, qimgv included, provides.
The image viewer IrfanView I used on windows is buggy on linux and provides a very user-friendly zoom (see https://github.com/easymodo/qimgv/issues/659) that qimgv doesn't have.
I couldn't use the default zoom because it was just too annoying, especially that you first had to zoom into the image THEN scroll the image and THEN move the cursor all the way to the edge to zoom into the location you want to inspect. Just annoying.
This lead to me implementing the IrfanView zoom (https://github.com/easymodo/qimgv/commit/0b0bfd39e8d7301b76828b2770fa045350ce9297).
At the beginning I didn't know anything about Qt and was pretty confused about everything.
But LLMs were a huge help explaining Qt concepts such as the 10 different coordinate systems Qt uses.
Once I got into the code it was quite fun to program in Qt so I also provided a bug fix and a few improvements for myself.


**Commit** https://github.com/easymodo/qimgv/commit/0b0bfd39e8d7301b76828b2770fa045350ce9297
Adds IrfanView zoom. Hover the pixel with the cursor you want to eventually center. Zoom in. The pixel will eventually be centered in the view IF you didn't move the cursor while zooming in.
IrfanView moves the cursor but I decided to not implement that because that is prone to being laggy and buggy.
Also, @easymodo, what about making this the default zoom of qimgv?

**Commit** https://github.com/easymodo/qimgv/commit/b4c537850bc61a98c1481aceab2d7d74383b7172
See this issue (https://github.com/easymodo/qimgv/issues/626).
It annoyed me so I let a LLM search for the issue and surprisingly it found it.

**Commit** https://github.com/easymodo/qimgv/commit/822ac9d03bf03a0e1bb2ccceb7b70c475bbd2354
When you assign "ESC" to "closeFullscreenOrExit", have a context menu open and press ESC then the application will close instead of closing the context menu.
ESC shouldn't close the application, but pop-up menus like the context menu first before closing the application.

**Commit** https://github.com/easymodo/qimgv/commit/9ea01f40bcc9088c64ed226beab72ce241e4fef5
I noticed that when I opened the image file with the "showInDirectory" action then the file isn't highlighted in linux mint.
Fixed it, rewrote some code + fixed space path bug.

**Commit** https://github.com/easymodo/qimgv/commit/b7b025d93f4a2a4d350eab93cefc65075d777f17
I noticed a few things in the code that could be improved.
This is almost only stuff that doesn't influence the behavior of the image viewer.

**Commit** https://github.com/easymodo/qimgv/commit/5694dd7a112a6267c20b9084304152113011633f
Also code improvement stuff but placed it in a seperate commit.

**Commit** https://github.com/easymodo/qimgv/commit/63fab0b43525b25fc9216da413982c5d9b238a1e
I use the "Lock View" feature in IrfanView frequently but in qimgv it is buggy for images of different sizes (e.g. go into top right corner, switch to next image, view isn't exactly in the top right corner).
I noticed that the code contains a bug (different from the one above) and is inefficient so I rewrote the whole thing from scratch. However, this commit **is incomplete** in a sense that it adds a setting to the config file but no GUI setting. I tried to edit the settings GUI with QCreator but gave up because the complexity was a bit overwhelming and I'm afraid I'll break something if I really try to add a setting. I planned to add the following GUI setting in the "Zoom options" setting box at the very bottom:

```
<horizontal seperation line>
Zoom preservation mode:
• Image width      • Image height      • Pixel density
Defines how zoom should be preserved when the preservation mode is activated (see togglePreserve actions) and you switch to another image.
```

**Commit** https://github.com/easymodo/qimgv/commit/82808c8ccdc9c6183177bfeeddea14cb5359900c
The "Lock zoom" feature is useless as far as I can tell. Maybe I'm just overseeing its usefullness, that's why I put the removal in a seperate commit and not in the previous one.

**Commit** https://github.com/easymodo/qimgv/commit/359e274b9c61591b3f349b375bb2cb4450e53023
In the settings menu there is a slider next to "Expand images, up to:" where there is an option called "-".
Nobody knows what this does the first time they're seeing this. I also saw somebody in the Issues section requesting the feature that "-" provides.
I rewrote stuff to make it more clear what this "-" does.
Notice that this will change the setting of users for this slider. They'll have to correct it again when they update to a version containing this commit.

**Commit** https://github.com/easymodo/qimgv/commit/ebd0120de13d5adbbe5734826eb789d24b6e9b6c
I added the word "Maximum" to the translation files.
**But I'm not sure if I did it correctly** since I'm a Qt beginner, that's why I put it into a seperate commit.
I entered `lupdate ~/Desktop/qimgv/ -ts ~/Desktop/qimgv/qimgv/res/translations/*` and then added the translation via QLinguist and saved the language files. Is that correct?

PS: I did not use LLMs to do maths or generate code, not even a single line.